### PR TITLE
Raise error only if status code is 404

### DIFF
--- a/rendercv/data_model.py
+++ b/rendercv/data_model.py
@@ -961,8 +961,9 @@ class PublicationEntry(Event):
 
         try:
             urllib.request.urlopen(doi_url)
-        except urllib.request.HTTPError:
-            raise ValueError(f"{doi} cannot be found in the DOI System 🤖")
+        except urllib.request.HTTPError as err:
+            if err.code == 404:
+                raise ValueError(f"{doi} cannot be found in the DOI System 🤖")
 
         return doi
 


### PR DESCRIPTION
Hello @sinaatalay,

i opened a new pull request with only 1 commit, which incorporates the changes that you mentioned.
The function will only raise a ValueError only if the status code is 404 (Not found).
