### PR TITLE
Fixed issues with new lines in markdown 

### DIFF
--- a/rendercv/themes/markdown/EducationEntry.j2.md
+++ b/rendercv/themes/markdown/EducationEntry.j2.md
@@ -1,9 +1,9 @@
 ## <<entry.institution>>, ((* if entry.degree *))<<entry.degree>> in ((* endif *))<<entry.area>>
 
-((* if entry.date_string *))- <<entry.date_string>> ((* endif *))
-
-((* if entry.location *))- <<entry.location>> ((* endif *))
-
+((* if entry.date_string *))- <<entry.date_string>>
+((* endif *))
+((* if entry.location *))- <<entry.location>>
+((* endif *))
 ((* for item in entry.highlights *))
 - <<item>>
 ((* endfor *))

--- a/rendercv/themes/markdown/ExperienceEntry.j2.md
+++ b/rendercv/themes/markdown/ExperienceEntry.j2.md
@@ -1,9 +1,9 @@
 ## <<entry.company>>, <<entry.position>>
 
-((* if entry.date_string *))- <<entry.date_string>> ((* endif *))
-
-((* if entry.location *))- <<entry.location>> ((* endif *))
-
+((* if entry.date_string *))- <<entry.date_string>>
+((* endif *))
+((* if entry.location *))- <<entry.location>>
+((* endif *))
 ((* for item in entry.highlights *))
 - <<item>>
 ((* endfor *))

--- a/rendercv/themes/markdown/NormalEntry.j2.md
+++ b/rendercv/themes/markdown/NormalEntry.j2.md
@@ -1,7 +1,9 @@
 ## <<entry.name>>
 
-((* if entry.date_string *))- <<entry.date_string>> ((* endif *))
-((* if entry.location *))- <<entry.location>> ((* endif *))
+((* if entry.date_string *))- <<entry.date_string>>
+((* endif *))
+((* if entry.location *))- <<entry.location>>
+((* endif *))
 ((* for item in entry.highlights *))
 - <<item>>
 ((* endfor *))

--- a/tests/testdata/test_generate_markdown_file/classic_filled.md
+++ b/tests/testdata/test_generate_markdown_file/classic_filled.md
@@ -47,192 +47,172 @@ This is a *TextEntry*. It is only a text and can be useful for sections like **S
 ## Some **Company**, Software Engineer
 
 
+## Some **Company**, Software Engineer
 
+- Istanbul, Turkey
 
 ## Some **Company**, Software Engineer
 
-
-- Istanbul, Turkey 
-
-## Some **Company**, Software Engineer
-
-- Sept. 2015 to present 
-
+- Sept. 2015 to present
 
 ## Some **Company**, Software Engineer
 
-- June 2020 
-
-
-## Some **Company**, Software Engineer
-
-- Sept. 2021 
-
+- June 2020
 
 ## Some **Company**, Software Engineer
 
+- Sept. 2021
 
+## Some **Company**, Software Engineer
 
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2015 to present 
-- Istanbul, Turkey 
+- Sept. 2015 to present
+- Istanbul, Turkey
 
 ## Some **Company**, Software Engineer
 
-- June 2020 
-- Istanbul, Turkey 
+- June 2020
+- Istanbul, Turkey
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
 
 ## Some **Company**, Software Engineer
 
-
-- Istanbul, Turkey 
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2015 to June 2020 
-
-
-## Some **Company**, Software Engineer
-
-- Sept. 2021 
-
+- Sept. 2015 to June 2020
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2015 to present 
+- Sept. 2021
 
+## Some **Company**, Software Engineer
+
+- Sept. 2015 to present
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-
+- Sept. 2021
 
 ## Some **Company**, Software Engineer
 
-- June 2020 
-
+- June 2020
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-
+- Sept. 2021
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2015 to June 2020 
-- Istanbul, Turkey 
+- Sept. 2015 to June 2020
+- Istanbul, Turkey
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2015 to present 
-- Istanbul, Turkey 
+- Sept. 2015 to present
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
 
 ## Some **Company**, Software Engineer
 
-- June 2020 
-- Istanbul, Turkey 
+- June 2020
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-
+- Sept. 2021
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2015 to June 2020 
-
+- Sept. 2015 to June 2020
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-
+- Sept. 2021
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-
+- Sept. 2021
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2015 to June 2020 
-- Istanbul, Turkey 
+- Sept. 2015 to June 2020
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-
+- Sept. 2021
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
@@ -241,384 +221,344 @@ This is a *TextEntry*. It is only a text and can be useful for sections like **S
 ## Boğaziçi University, Mechanical Engineering
 
 
-
-
 ## Boğaziçi University, BS in Mechanical Engineering
 
 
+## Boğaziçi University, Mechanical Engineering
 
+- Istanbul, Turkey
 
 ## Boğaziçi University, Mechanical Engineering
 
-
-- Istanbul, Turkey 
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2015 to present 
-
+- Sept. 2015 to present
 
 ## Boğaziçi University, Mechanical Engineering
 
-- June 2020 
-
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2021 
-
+- June 2020
 
 ## Boğaziçi University, Mechanical Engineering
 
+- Sept. 2021
 
+## Boğaziçi University, Mechanical Engineering
 
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, BS in Mechanical Engineering
 
-
-- Istanbul, Turkey 
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2015 to present 
-
+- Istanbul, Turkey
 
 ## Boğaziçi University, BS in Mechanical Engineering
 
-- June 2020 
-
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2021 
-
+- Sept. 2015 to present
 
 ## Boğaziçi University, BS in Mechanical Engineering
 
+- June 2020
 
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+
+## Boğaziçi University, BS in Mechanical Engineering
 
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2015 to present 
-- Istanbul, Turkey 
+- Sept. 2015 to present
+- Istanbul, Turkey
 
 ## Boğaziçi University, Mechanical Engineering
 
-- June 2020 
-- Istanbul, Turkey 
+- June 2020
+- Istanbul, Turkey
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
 
 ## Boğaziçi University, Mechanical Engineering
 
-
-- Istanbul, Turkey 
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2015 to June 2020 
-
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2021 
-
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2015 to present 
-
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2021 
-
-
-## Boğaziçi University, Mechanical Engineering
-
-- June 2020 
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+- Sept. 2015 to June 2020
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2021 
+- Sept. 2021
 
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+## Boğaziçi University, Mechanical Engineering
 
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2015 to present 
-- Istanbul, Turkey 
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- June 2020 
-- Istanbul, Turkey 
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2021 
-- Istanbul, Turkey 
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-
-- Istanbul, Turkey 
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2015 to June 2020 
-
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2021 
-
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2015 to present 
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2021 
-
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- June 2020 
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2021 
-
+- Sept. 2015 to present
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2015 to June 2020 
-- Istanbul, Turkey 
+- Sept. 2021
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2021 
-- Istanbul, Turkey 
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2015 to present 
-- Istanbul, Turkey 
+- June 2020
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2021 
-- Istanbul, Turkey 
-
-## Boğaziçi University, Mechanical Engineering
-
-- June 2020 
-- Istanbul, Turkey 
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2021 
-- Istanbul, Turkey 
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2021 
-
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2015 to June 2020 
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2021 
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2021 
-
+- Sept. 2021
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, BS in Mechanical Engineering
 
-- Sept. 2015 to June 2020 
-- Istanbul, Turkey 
+- Sept. 2015 to present
+- Istanbul, Turkey
 
 ## Boğaziçi University, BS in Mechanical Engineering
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- June 2020
+- Istanbul, Turkey
 
 ## Boğaziçi University, BS in Mechanical Engineering
 
-- Sept. 2015 to present 
-- Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, BS in Mechanical Engineering
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2015 to June 2020
 
 ## Boğaziçi University, BS in Mechanical Engineering
 
-- June 2020 
-- Istanbul, Turkey 
+- Sept. 2021
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2015 to present
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, BS in Mechanical Engineering
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2021
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- June 2020
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, BS in Mechanical Engineering
 
-- Sept. 2021 
-
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2015 to June 2020 
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2021 
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2021 
-
+- Sept. 2021
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2015 to June 2020
+- Istanbul, Turkey
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2015 to June 2020 
-- Istanbul, Turkey 
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+- Sept. 2021
+- Istanbul, Turkey
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2021 
-- Istanbul, Turkey 
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2015 to present
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2021 
+- Sept. 2021
+- Istanbul, Turkey
 
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+## Boğaziçi University, Mechanical Engineering
 
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2021 
-- Istanbul, Turkey 
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2015 to June 2020 
-- Istanbul, Turkey 
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2021 
-- Istanbul, Turkey 
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2021 
-- Istanbul, Turkey 
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2021 
-
+- June 2020
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, Mechanical Engineering
+
+- Sept. 2021
+
+## Boğaziçi University, Mechanical Engineering
+
+- Sept. 2015 to June 2020
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, Mechanical Engineering
+
+- Sept. 2021
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, Mechanical Engineering
+
+- Sept. 2021
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, BS in Mechanical Engineering
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2015 to June 2020
+- Istanbul, Turkey
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+- Istanbul, Turkey
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2015 to present
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+- Istanbul, Turkey
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- June 2020
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2015 to June 2020
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, Mechanical Engineering
+
+- Sept. 2021
+- Istanbul, Turkey
+
+## Boğaziçi University, Mechanical Engineering
+
+- Sept. 2015 to June 2020
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, Mechanical Engineering
+
+- Sept. 2021
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, Mechanical Engineering
+
+- Sept. 2021
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, Mechanical Engineering
+
+- Sept. 2021
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+- Istanbul, Turkey
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2015 to June 2020
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, Mechanical Engineering
+
+- Sept. 2021
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
@@ -629,16 +569,20 @@ This is a *TextEntry*. It is only a text and can be useful for sections like **S
 
 ## My Project
 
-- Istanbul, Turkey 
+- Istanbul, Turkey
+
 ## My Project
 
-- Sept. 2015 to present 
+- Sept. 2015 to present
+
 ## My Project
 
-- June 2020 
+- June 2020
+
 ## My Project
 
-- Sept. 2021 
+- Sept. 2021
+
 ## My Project
 
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
@@ -646,110 +590,150 @@ This is a *TextEntry*. It is only a text and can be useful for sections like **S
 
 ## My Project
 
-- Sept. 2015 to present - Istanbul, Turkey 
+- Sept. 2015 to present
+- Istanbul, Turkey
+
 ## My Project
 
-- June 2020 - Istanbul, Turkey 
+- June 2020
+- Istanbul, Turkey
+
 ## My Project
 
-- Sept. 2021 - Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
+
 ## My Project
 
-- Istanbul, Turkey - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2015 to June 2020 
+- Sept. 2015 to June 2020
+
 ## My Project
 
-- Sept. 2021 
+- Sept. 2021
+
 ## My Project
 
-- Sept. 2015 to present - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2015 to present
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 
+- Sept. 2021
+
 ## My Project
 
-- June 2020 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- June 2020
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2021
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2015 to June 2020 - Istanbul, Turkey 
+- Sept. 2015 to June 2020
+- Istanbul, Turkey
+
 ## My Project
 
-- Sept. 2021 - Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
+
 ## My Project
 
-- Sept. 2015 to present - Istanbul, Turkey - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2015 to present
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 - Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
+
 ## My Project
 
-- June 2020 - Istanbul, Turkey - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- June 2020
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 - Istanbul, Turkey - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2021
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 
+- Sept. 2021
+
 ## My Project
 
-- Sept. 2015 to June 2020 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2015 to June 2020
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2021
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2021
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 - Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
+
 ## My Project
 
-- Sept. 2015 to June 2020 - Istanbul, Turkey - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2015 to June 2020
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 - Istanbul, Turkey - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2021
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 - Istanbul, Turkey - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2021
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2021
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 - Istanbul, Turkey - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2021
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 # One Line Entries

--- a/tests/testdata/test_generate_markdown_file/engineeringresumes_filled.md
+++ b/tests/testdata/test_generate_markdown_file/engineeringresumes_filled.md
@@ -47,192 +47,172 @@ This is a *TextEntry*. It is only a text and can be useful for sections like **S
 ## Some **Company**, Software Engineer
 
 
+## Some **Company**, Software Engineer
 
+- Istanbul, Turkey
 
 ## Some **Company**, Software Engineer
 
-
-- Istanbul, Turkey 
-
-## Some **Company**, Software Engineer
-
-- Sept. 2015 to present 
-
+- Sept. 2015 to present
 
 ## Some **Company**, Software Engineer
 
-- June 2020 
-
-
-## Some **Company**, Software Engineer
-
-- Sept. 2021 
-
+- June 2020
 
 ## Some **Company**, Software Engineer
 
+- Sept. 2021
 
+## Some **Company**, Software Engineer
 
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2015 to present 
-- Istanbul, Turkey 
+- Sept. 2015 to present
+- Istanbul, Turkey
 
 ## Some **Company**, Software Engineer
 
-- June 2020 
-- Istanbul, Turkey 
+- June 2020
+- Istanbul, Turkey
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
 
 ## Some **Company**, Software Engineer
 
-
-- Istanbul, Turkey 
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2015 to June 2020 
-
-
-## Some **Company**, Software Engineer
-
-- Sept. 2021 
-
+- Sept. 2015 to June 2020
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2015 to present 
+- Sept. 2021
 
+## Some **Company**, Software Engineer
+
+- Sept. 2015 to present
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-
+- Sept. 2021
 
 ## Some **Company**, Software Engineer
 
-- June 2020 
-
+- June 2020
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-
+- Sept. 2021
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2015 to June 2020 
-- Istanbul, Turkey 
+- Sept. 2015 to June 2020
+- Istanbul, Turkey
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2015 to present 
-- Istanbul, Turkey 
+- Sept. 2015 to present
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
 
 ## Some **Company**, Software Engineer
 
-- June 2020 
-- Istanbul, Turkey 
+- June 2020
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-
+- Sept. 2021
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2015 to June 2020 
-
+- Sept. 2015 to June 2020
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-
+- Sept. 2021
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-
+- Sept. 2021
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2015 to June 2020 
-- Istanbul, Turkey 
+- Sept. 2015 to June 2020
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-
+- Sept. 2021
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
@@ -241,384 +221,344 @@ This is a *TextEntry*. It is only a text and can be useful for sections like **S
 ## Boğaziçi University, Mechanical Engineering
 
 
-
-
 ## Boğaziçi University, BS in Mechanical Engineering
 
 
+## Boğaziçi University, Mechanical Engineering
 
+- Istanbul, Turkey
 
 ## Boğaziçi University, Mechanical Engineering
 
-
-- Istanbul, Turkey 
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2015 to present 
-
+- Sept. 2015 to present
 
 ## Boğaziçi University, Mechanical Engineering
 
-- June 2020 
-
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2021 
-
+- June 2020
 
 ## Boğaziçi University, Mechanical Engineering
 
+- Sept. 2021
 
+## Boğaziçi University, Mechanical Engineering
 
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, BS in Mechanical Engineering
 
-
-- Istanbul, Turkey 
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2015 to present 
-
+- Istanbul, Turkey
 
 ## Boğaziçi University, BS in Mechanical Engineering
 
-- June 2020 
-
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2021 
-
+- Sept. 2015 to present
 
 ## Boğaziçi University, BS in Mechanical Engineering
 
+- June 2020
 
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+
+## Boğaziçi University, BS in Mechanical Engineering
 
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2015 to present 
-- Istanbul, Turkey 
+- Sept. 2015 to present
+- Istanbul, Turkey
 
 ## Boğaziçi University, Mechanical Engineering
 
-- June 2020 
-- Istanbul, Turkey 
+- June 2020
+- Istanbul, Turkey
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
 
 ## Boğaziçi University, Mechanical Engineering
 
-
-- Istanbul, Turkey 
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2015 to June 2020 
-
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2021 
-
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2015 to present 
-
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2021 
-
-
-## Boğaziçi University, Mechanical Engineering
-
-- June 2020 
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+- Sept. 2015 to June 2020
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2021 
+- Sept. 2021
 
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+## Boğaziçi University, Mechanical Engineering
 
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2015 to present 
-- Istanbul, Turkey 
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- June 2020 
-- Istanbul, Turkey 
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2021 
-- Istanbul, Turkey 
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-
-- Istanbul, Turkey 
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2015 to June 2020 
-
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2021 
-
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2015 to present 
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2021 
-
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- June 2020 
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2021 
-
+- Sept. 2015 to present
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2015 to June 2020 
-- Istanbul, Turkey 
+- Sept. 2021
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2021 
-- Istanbul, Turkey 
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2015 to present 
-- Istanbul, Turkey 
+- June 2020
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2021 
-- Istanbul, Turkey 
-
-## Boğaziçi University, Mechanical Engineering
-
-- June 2020 
-- Istanbul, Turkey 
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2021 
-- Istanbul, Turkey 
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2021 
-
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2015 to June 2020 
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2021 
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2021 
-
+- Sept. 2021
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, BS in Mechanical Engineering
 
-- Sept. 2015 to June 2020 
-- Istanbul, Turkey 
+- Sept. 2015 to present
+- Istanbul, Turkey
 
 ## Boğaziçi University, BS in Mechanical Engineering
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- June 2020
+- Istanbul, Turkey
 
 ## Boğaziçi University, BS in Mechanical Engineering
 
-- Sept. 2015 to present 
-- Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, BS in Mechanical Engineering
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2015 to June 2020
 
 ## Boğaziçi University, BS in Mechanical Engineering
 
-- June 2020 
-- Istanbul, Turkey 
+- Sept. 2021
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2015 to present
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, BS in Mechanical Engineering
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2021
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- June 2020
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, BS in Mechanical Engineering
 
-- Sept. 2021 
-
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2015 to June 2020 
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2021 
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2021 
-
+- Sept. 2021
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2015 to June 2020
+- Istanbul, Turkey
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2015 to June 2020 
-- Istanbul, Turkey 
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+- Sept. 2021
+- Istanbul, Turkey
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2021 
-- Istanbul, Turkey 
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2015 to present
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2021 
+- Sept. 2021
+- Istanbul, Turkey
 
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+## Boğaziçi University, Mechanical Engineering
 
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2021 
-- Istanbul, Turkey 
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2015 to June 2020 
-- Istanbul, Turkey 
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2021 
-- Istanbul, Turkey 
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2021 
-- Istanbul, Turkey 
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2021 
-
+- June 2020
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, Mechanical Engineering
+
+- Sept. 2021
+
+## Boğaziçi University, Mechanical Engineering
+
+- Sept. 2015 to June 2020
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, Mechanical Engineering
+
+- Sept. 2021
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, Mechanical Engineering
+
+- Sept. 2021
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, BS in Mechanical Engineering
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2015 to June 2020
+- Istanbul, Turkey
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+- Istanbul, Turkey
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2015 to present
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+- Istanbul, Turkey
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- June 2020
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2015 to June 2020
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, Mechanical Engineering
+
+- Sept. 2021
+- Istanbul, Turkey
+
+## Boğaziçi University, Mechanical Engineering
+
+- Sept. 2015 to June 2020
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, Mechanical Engineering
+
+- Sept. 2021
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, Mechanical Engineering
+
+- Sept. 2021
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, Mechanical Engineering
+
+- Sept. 2021
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+- Istanbul, Turkey
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2015 to June 2020
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, Mechanical Engineering
+
+- Sept. 2021
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
@@ -629,16 +569,20 @@ This is a *TextEntry*. It is only a text and can be useful for sections like **S
 
 ## My Project
 
-- Istanbul, Turkey 
+- Istanbul, Turkey
+
 ## My Project
 
-- Sept. 2015 to present 
+- Sept. 2015 to present
+
 ## My Project
 
-- June 2020 
+- June 2020
+
 ## My Project
 
-- Sept. 2021 
+- Sept. 2021
+
 ## My Project
 
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
@@ -646,110 +590,150 @@ This is a *TextEntry*. It is only a text and can be useful for sections like **S
 
 ## My Project
 
-- Sept. 2015 to present - Istanbul, Turkey 
+- Sept. 2015 to present
+- Istanbul, Turkey
+
 ## My Project
 
-- June 2020 - Istanbul, Turkey 
+- June 2020
+- Istanbul, Turkey
+
 ## My Project
 
-- Sept. 2021 - Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
+
 ## My Project
 
-- Istanbul, Turkey - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2015 to June 2020 
+- Sept. 2015 to June 2020
+
 ## My Project
 
-- Sept. 2021 
+- Sept. 2021
+
 ## My Project
 
-- Sept. 2015 to present - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2015 to present
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 
+- Sept. 2021
+
 ## My Project
 
-- June 2020 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- June 2020
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2021
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2015 to June 2020 - Istanbul, Turkey 
+- Sept. 2015 to June 2020
+- Istanbul, Turkey
+
 ## My Project
 
-- Sept. 2021 - Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
+
 ## My Project
 
-- Sept. 2015 to present - Istanbul, Turkey - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2015 to present
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 - Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
+
 ## My Project
 
-- June 2020 - Istanbul, Turkey - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- June 2020
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 - Istanbul, Turkey - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2021
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 
+- Sept. 2021
+
 ## My Project
 
-- Sept. 2015 to June 2020 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2015 to June 2020
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2021
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2021
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 - Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
+
 ## My Project
 
-- Sept. 2015 to June 2020 - Istanbul, Turkey - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2015 to June 2020
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 - Istanbul, Turkey - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2021
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 - Istanbul, Turkey - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2021
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2021
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 - Istanbul, Turkey - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2021
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 # One Line Entries

--- a/tests/testdata/test_generate_markdown_file/moderncv_filled.md
+++ b/tests/testdata/test_generate_markdown_file/moderncv_filled.md
@@ -47,192 +47,172 @@ This is a *TextEntry*. It is only a text and can be useful for sections like **S
 ## Some **Company**, Software Engineer
 
 
+## Some **Company**, Software Engineer
 
+- Istanbul, Turkey
 
 ## Some **Company**, Software Engineer
 
-
-- Istanbul, Turkey 
-
-## Some **Company**, Software Engineer
-
-- Sept. 2015 to present 
-
+- Sept. 2015 to present
 
 ## Some **Company**, Software Engineer
 
-- June 2020 
-
-
-## Some **Company**, Software Engineer
-
-- Sept. 2021 
-
+- June 2020
 
 ## Some **Company**, Software Engineer
 
+- Sept. 2021
 
+## Some **Company**, Software Engineer
 
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2015 to present 
-- Istanbul, Turkey 
+- Sept. 2015 to present
+- Istanbul, Turkey
 
 ## Some **Company**, Software Engineer
 
-- June 2020 
-- Istanbul, Turkey 
+- June 2020
+- Istanbul, Turkey
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
 
 ## Some **Company**, Software Engineer
 
-
-- Istanbul, Turkey 
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2015 to June 2020 
-
-
-## Some **Company**, Software Engineer
-
-- Sept. 2021 
-
+- Sept. 2015 to June 2020
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2015 to present 
+- Sept. 2021
 
+## Some **Company**, Software Engineer
+
+- Sept. 2015 to present
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-
+- Sept. 2021
 
 ## Some **Company**, Software Engineer
 
-- June 2020 
-
+- June 2020
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-
+- Sept. 2021
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2015 to June 2020 
-- Istanbul, Turkey 
+- Sept. 2015 to June 2020
+- Istanbul, Turkey
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2015 to present 
-- Istanbul, Turkey 
+- Sept. 2015 to present
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
 
 ## Some **Company**, Software Engineer
 
-- June 2020 
-- Istanbul, Turkey 
+- June 2020
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-
+- Sept. 2021
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2015 to June 2020 
-
+- Sept. 2015 to June 2020
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-
+- Sept. 2021
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-
+- Sept. 2021
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2015 to June 2020 
-- Istanbul, Turkey 
+- Sept. 2015 to June 2020
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-
+- Sept. 2021
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
@@ -241,384 +221,344 @@ This is a *TextEntry*. It is only a text and can be useful for sections like **S
 ## Boğaziçi University, Mechanical Engineering
 
 
-
-
 ## Boğaziçi University, BS in Mechanical Engineering
 
 
+## Boğaziçi University, Mechanical Engineering
 
+- Istanbul, Turkey
 
 ## Boğaziçi University, Mechanical Engineering
 
-
-- Istanbul, Turkey 
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2015 to present 
-
+- Sept. 2015 to present
 
 ## Boğaziçi University, Mechanical Engineering
 
-- June 2020 
-
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2021 
-
+- June 2020
 
 ## Boğaziçi University, Mechanical Engineering
 
+- Sept. 2021
 
+## Boğaziçi University, Mechanical Engineering
 
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, BS in Mechanical Engineering
 
-
-- Istanbul, Turkey 
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2015 to present 
-
+- Istanbul, Turkey
 
 ## Boğaziçi University, BS in Mechanical Engineering
 
-- June 2020 
-
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2021 
-
+- Sept. 2015 to present
 
 ## Boğaziçi University, BS in Mechanical Engineering
 
+- June 2020
 
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+
+## Boğaziçi University, BS in Mechanical Engineering
 
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2015 to present 
-- Istanbul, Turkey 
+- Sept. 2015 to present
+- Istanbul, Turkey
 
 ## Boğaziçi University, Mechanical Engineering
 
-- June 2020 
-- Istanbul, Turkey 
+- June 2020
+- Istanbul, Turkey
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
 
 ## Boğaziçi University, Mechanical Engineering
 
-
-- Istanbul, Turkey 
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2015 to June 2020 
-
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2021 
-
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2015 to present 
-
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2021 
-
-
-## Boğaziçi University, Mechanical Engineering
-
-- June 2020 
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+- Sept. 2015 to June 2020
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2021 
+- Sept. 2021
 
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+## Boğaziçi University, Mechanical Engineering
 
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2015 to present 
-- Istanbul, Turkey 
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- June 2020 
-- Istanbul, Turkey 
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2021 
-- Istanbul, Turkey 
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-
-- Istanbul, Turkey 
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2015 to June 2020 
-
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2021 
-
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2015 to present 
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2021 
-
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- June 2020 
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2021 
-
+- Sept. 2015 to present
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2015 to June 2020 
-- Istanbul, Turkey 
+- Sept. 2021
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2021 
-- Istanbul, Turkey 
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2015 to present 
-- Istanbul, Turkey 
+- June 2020
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2021 
-- Istanbul, Turkey 
-
-## Boğaziçi University, Mechanical Engineering
-
-- June 2020 
-- Istanbul, Turkey 
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2021 
-- Istanbul, Turkey 
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2021 
-
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2015 to June 2020 
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2021 
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2021 
-
+- Sept. 2021
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, BS in Mechanical Engineering
 
-- Sept. 2015 to June 2020 
-- Istanbul, Turkey 
+- Sept. 2015 to present
+- Istanbul, Turkey
 
 ## Boğaziçi University, BS in Mechanical Engineering
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- June 2020
+- Istanbul, Turkey
 
 ## Boğaziçi University, BS in Mechanical Engineering
 
-- Sept. 2015 to present 
-- Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, BS in Mechanical Engineering
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2015 to June 2020
 
 ## Boğaziçi University, BS in Mechanical Engineering
 
-- June 2020 
-- Istanbul, Turkey 
+- Sept. 2021
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2015 to present
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, BS in Mechanical Engineering
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2021
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- June 2020
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, BS in Mechanical Engineering
 
-- Sept. 2021 
-
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2015 to June 2020 
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2021 
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2021 
-
+- Sept. 2021
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2015 to June 2020
+- Istanbul, Turkey
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2015 to June 2020 
-- Istanbul, Turkey 
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+- Sept. 2021
+- Istanbul, Turkey
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2021 
-- Istanbul, Turkey 
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2015 to present
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2021 
+- Sept. 2021
+- Istanbul, Turkey
 
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+## Boğaziçi University, Mechanical Engineering
 
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2021 
-- Istanbul, Turkey 
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2015 to June 2020 
-- Istanbul, Turkey 
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2021 
-- Istanbul, Turkey 
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2021 
-- Istanbul, Turkey 
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2021 
-
+- June 2020
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, Mechanical Engineering
+
+- Sept. 2021
+
+## Boğaziçi University, Mechanical Engineering
+
+- Sept. 2015 to June 2020
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, Mechanical Engineering
+
+- Sept. 2021
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, Mechanical Engineering
+
+- Sept. 2021
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, BS in Mechanical Engineering
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2015 to June 2020
+- Istanbul, Turkey
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+- Istanbul, Turkey
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2015 to present
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+- Istanbul, Turkey
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- June 2020
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2015 to June 2020
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, Mechanical Engineering
+
+- Sept. 2021
+- Istanbul, Turkey
+
+## Boğaziçi University, Mechanical Engineering
+
+- Sept. 2015 to June 2020
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, Mechanical Engineering
+
+- Sept. 2021
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, Mechanical Engineering
+
+- Sept. 2021
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, Mechanical Engineering
+
+- Sept. 2021
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+- Istanbul, Turkey
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2015 to June 2020
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, Mechanical Engineering
+
+- Sept. 2021
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
@@ -629,16 +569,20 @@ This is a *TextEntry*. It is only a text and can be useful for sections like **S
 
 ## My Project
 
-- Istanbul, Turkey 
+- Istanbul, Turkey
+
 ## My Project
 
-- Sept. 2015 to present 
+- Sept. 2015 to present
+
 ## My Project
 
-- June 2020 
+- June 2020
+
 ## My Project
 
-- Sept. 2021 
+- Sept. 2021
+
 ## My Project
 
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
@@ -646,110 +590,150 @@ This is a *TextEntry*. It is only a text and can be useful for sections like **S
 
 ## My Project
 
-- Sept. 2015 to present - Istanbul, Turkey 
+- Sept. 2015 to present
+- Istanbul, Turkey
+
 ## My Project
 
-- June 2020 - Istanbul, Turkey 
+- June 2020
+- Istanbul, Turkey
+
 ## My Project
 
-- Sept. 2021 - Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
+
 ## My Project
 
-- Istanbul, Turkey - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2015 to June 2020 
+- Sept. 2015 to June 2020
+
 ## My Project
 
-- Sept. 2021 
+- Sept. 2021
+
 ## My Project
 
-- Sept. 2015 to present - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2015 to present
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 
+- Sept. 2021
+
 ## My Project
 
-- June 2020 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- June 2020
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2021
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2015 to June 2020 - Istanbul, Turkey 
+- Sept. 2015 to June 2020
+- Istanbul, Turkey
+
 ## My Project
 
-- Sept. 2021 - Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
+
 ## My Project
 
-- Sept. 2015 to present - Istanbul, Turkey - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2015 to present
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 - Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
+
 ## My Project
 
-- June 2020 - Istanbul, Turkey - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- June 2020
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 - Istanbul, Turkey - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2021
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 
+- Sept. 2021
+
 ## My Project
 
-- Sept. 2015 to June 2020 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2015 to June 2020
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2021
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2021
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 - Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
+
 ## My Project
 
-- Sept. 2015 to June 2020 - Istanbul, Turkey - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2015 to June 2020
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 - Istanbul, Turkey - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2021
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 - Istanbul, Turkey - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2021
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2021
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 - Istanbul, Turkey - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2021
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 # One Line Entries

--- a/tests/testdata/test_generate_markdown_file/sb2nov_filled.md
+++ b/tests/testdata/test_generate_markdown_file/sb2nov_filled.md
@@ -47,192 +47,172 @@ This is a *TextEntry*. It is only a text and can be useful for sections like **S
 ## Some **Company**, Software Engineer
 
 
+## Some **Company**, Software Engineer
 
+- Istanbul, Turkey
 
 ## Some **Company**, Software Engineer
 
-
-- Istanbul, Turkey 
-
-## Some **Company**, Software Engineer
-
-- Sept. 2015 to present 
-
+- Sept. 2015 to present
 
 ## Some **Company**, Software Engineer
 
-- June 2020 
-
-
-## Some **Company**, Software Engineer
-
-- Sept. 2021 
-
+- June 2020
 
 ## Some **Company**, Software Engineer
 
+- Sept. 2021
 
+## Some **Company**, Software Engineer
 
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2015 to present 
-- Istanbul, Turkey 
+- Sept. 2015 to present
+- Istanbul, Turkey
 
 ## Some **Company**, Software Engineer
 
-- June 2020 
-- Istanbul, Turkey 
+- June 2020
+- Istanbul, Turkey
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
 
 ## Some **Company**, Software Engineer
 
-
-- Istanbul, Turkey 
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2015 to June 2020 
-
-
-## Some **Company**, Software Engineer
-
-- Sept. 2021 
-
+- Sept. 2015 to June 2020
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2015 to present 
+- Sept. 2021
 
+## Some **Company**, Software Engineer
+
+- Sept. 2015 to present
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-
+- Sept. 2021
 
 ## Some **Company**, Software Engineer
 
-- June 2020 
-
+- June 2020
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-
+- Sept. 2021
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2015 to June 2020 
-- Istanbul, Turkey 
+- Sept. 2015 to June 2020
+- Istanbul, Turkey
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2015 to present 
-- Istanbul, Turkey 
+- Sept. 2015 to present
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
 
 ## Some **Company**, Software Engineer
 
-- June 2020 
-- Istanbul, Turkey 
+- June 2020
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-
+- Sept. 2021
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2015 to June 2020 
-
+- Sept. 2015 to June 2020
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-
+- Sept. 2021
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-
+- Sept. 2021
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2015 to June 2020 
-- Istanbul, Turkey 
+- Sept. 2015 to June 2020
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-
+- Sept. 2021
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Some **Company**, Software Engineer
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
@@ -241,384 +221,344 @@ This is a *TextEntry*. It is only a text and can be useful for sections like **S
 ## Boğaziçi University, Mechanical Engineering
 
 
-
-
 ## Boğaziçi University, BS in Mechanical Engineering
 
 
+## Boğaziçi University, Mechanical Engineering
 
+- Istanbul, Turkey
 
 ## Boğaziçi University, Mechanical Engineering
 
-
-- Istanbul, Turkey 
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2015 to present 
-
+- Sept. 2015 to present
 
 ## Boğaziçi University, Mechanical Engineering
 
-- June 2020 
-
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2021 
-
+- June 2020
 
 ## Boğaziçi University, Mechanical Engineering
 
+- Sept. 2021
 
+## Boğaziçi University, Mechanical Engineering
 
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, BS in Mechanical Engineering
 
-
-- Istanbul, Turkey 
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2015 to present 
-
+- Istanbul, Turkey
 
 ## Boğaziçi University, BS in Mechanical Engineering
 
-- June 2020 
-
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2021 
-
+- Sept. 2015 to present
 
 ## Boğaziçi University, BS in Mechanical Engineering
 
+- June 2020
 
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+
+## Boğaziçi University, BS in Mechanical Engineering
 
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2015 to present 
-- Istanbul, Turkey 
+- Sept. 2015 to present
+- Istanbul, Turkey
 
 ## Boğaziçi University, Mechanical Engineering
 
-- June 2020 
-- Istanbul, Turkey 
+- June 2020
+- Istanbul, Turkey
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
 
 ## Boğaziçi University, Mechanical Engineering
 
-
-- Istanbul, Turkey 
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2015 to June 2020 
-
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2021 
-
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2015 to present 
-
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2021 
-
-
-## Boğaziçi University, Mechanical Engineering
-
-- June 2020 
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+- Sept. 2015 to June 2020
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2021 
+- Sept. 2021
 
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+## Boğaziçi University, Mechanical Engineering
 
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2015 to present 
-- Istanbul, Turkey 
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- June 2020 
-- Istanbul, Turkey 
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2021 
-- Istanbul, Turkey 
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-
-- Istanbul, Turkey 
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2015 to June 2020 
-
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2021 
-
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2015 to present 
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2021 
-
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- June 2020 
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2021 
-
+- Sept. 2015 to present
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2015 to June 2020 
-- Istanbul, Turkey 
+- Sept. 2021
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2021 
-- Istanbul, Turkey 
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2015 to present 
-- Istanbul, Turkey 
+- June 2020
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2021 
-- Istanbul, Turkey 
-
-## Boğaziçi University, Mechanical Engineering
-
-- June 2020 
-- Istanbul, Turkey 
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2021 
-- Istanbul, Turkey 
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2021 
-
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2015 to June 2020 
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2021 
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2021 
-
+- Sept. 2021
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, BS in Mechanical Engineering
 
-- Sept. 2015 to June 2020 
-- Istanbul, Turkey 
+- Sept. 2015 to present
+- Istanbul, Turkey
 
 ## Boğaziçi University, BS in Mechanical Engineering
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- June 2020
+- Istanbul, Turkey
 
 ## Boğaziçi University, BS in Mechanical Engineering
 
-- Sept. 2015 to present 
-- Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, BS in Mechanical Engineering
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2015 to June 2020
 
 ## Boğaziçi University, BS in Mechanical Engineering
 
-- June 2020 
-- Istanbul, Turkey 
+- Sept. 2021
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2015 to present
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, BS in Mechanical Engineering
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2021
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- June 2020
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, BS in Mechanical Engineering
 
-- Sept. 2021 
-
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2015 to June 2020 
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2021 
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2021 
-
+- Sept. 2021
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2015 to June 2020
+- Istanbul, Turkey
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2015 to June 2020 
-- Istanbul, Turkey 
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+- Sept. 2021
+- Istanbul, Turkey
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2021 
-- Istanbul, Turkey 
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, Mechanical Engineering
-
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2015 to present
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2021 
+- Sept. 2021
+- Istanbul, Turkey
 
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+## Boğaziçi University, Mechanical Engineering
 
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2021 
-- Istanbul, Turkey 
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2015 to June 2020 
-- Istanbul, Turkey 
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2021 
-- Istanbul, Turkey 
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2021 
-- Istanbul, Turkey 
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-## Boğaziçi University, BS in Mechanical Engineering
-
-- Sept. 2021 
-
+- June 2020
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, Mechanical Engineering
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, Mechanical Engineering
+
+- Sept. 2021
+
+## Boğaziçi University, Mechanical Engineering
+
+- Sept. 2015 to June 2020
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, Mechanical Engineering
+
+- Sept. 2021
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, Mechanical Engineering
+
+- Sept. 2021
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## Boğaziçi University, BS in Mechanical Engineering
 
-- Sept. 2021 
-- Istanbul, Turkey 
+- Sept. 2015 to June 2020
+- Istanbul, Turkey
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+- Istanbul, Turkey
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2015 to present
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+- Istanbul, Turkey
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- June 2020
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2015 to June 2020
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, Mechanical Engineering
+
+- Sept. 2021
+- Istanbul, Turkey
+
+## Boğaziçi University, Mechanical Engineering
+
+- Sept. 2015 to June 2020
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, Mechanical Engineering
+
+- Sept. 2021
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, Mechanical Engineering
+
+- Sept. 2021
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, Mechanical Engineering
+
+- Sept. 2021
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+- Istanbul, Turkey
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2015 to June 2020
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, Mechanical Engineering
+
+- Sept. 2021
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+## Boğaziçi University, BS in Mechanical Engineering
+
+- Sept. 2021
+- Istanbul, Turkey
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
@@ -629,16 +569,20 @@ This is a *TextEntry*. It is only a text and can be useful for sections like **S
 
 ## My Project
 
-- Istanbul, Turkey 
+- Istanbul, Turkey
+
 ## My Project
 
-- Sept. 2015 to present 
+- Sept. 2015 to present
+
 ## My Project
 
-- June 2020 
+- June 2020
+
 ## My Project
 
-- Sept. 2021 
+- Sept. 2021
+
 ## My Project
 
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
@@ -646,110 +590,150 @@ This is a *TextEntry*. It is only a text and can be useful for sections like **S
 
 ## My Project
 
-- Sept. 2015 to present - Istanbul, Turkey 
+- Sept. 2015 to present
+- Istanbul, Turkey
+
 ## My Project
 
-- June 2020 - Istanbul, Turkey 
+- June 2020
+- Istanbul, Turkey
+
 ## My Project
 
-- Sept. 2021 - Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
+
 ## My Project
 
-- Istanbul, Turkey - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2015 to June 2020 
+- Sept. 2015 to June 2020
+
 ## My Project
 
-- Sept. 2021 
+- Sept. 2021
+
 ## My Project
 
-- Sept. 2015 to present - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2015 to present
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 
+- Sept. 2021
+
 ## My Project
 
-- June 2020 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- June 2020
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2021
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2015 to June 2020 - Istanbul, Turkey 
+- Sept. 2015 to June 2020
+- Istanbul, Turkey
+
 ## My Project
 
-- Sept. 2021 - Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
+
 ## My Project
 
-- Sept. 2015 to present - Istanbul, Turkey - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2015 to present
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 - Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
+
 ## My Project
 
-- June 2020 - Istanbul, Turkey - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- June 2020
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 - Istanbul, Turkey - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2021
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 
+- Sept. 2021
+
 ## My Project
 
-- Sept. 2015 to June 2020 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2015 to June 2020
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2021
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2021
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 - Istanbul, Turkey 
+- Sept. 2021
+- Istanbul, Turkey
+
 ## My Project
 
-- Sept. 2015 to June 2020 - Istanbul, Turkey - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2015 to June 2020
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 - Istanbul, Turkey - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2021
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 - Istanbul, Turkey - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2021
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2021
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 ## My Project
 
-- Sept. 2021 - Istanbul, Turkey - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
+- Sept. 2021
+- Istanbul, Turkey
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
 
 # One Line Entries

--- a/tests/testdata/test_markdown_to_html/classic_filled.html
+++ b/tests/testdata/test_markdown_to_html/classic_filled.html
@@ -47,19 +47,19 @@
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Istanbul, Turkey </li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2015 to present </li>
+<li>Sept. 2015 to present</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>June 2020 </li>
+<li>June 2020</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2021 </li>
+<li>Sept. 2021</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
@@ -68,177 +68,149 @@
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2015 to present </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2015 to present</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>June 2020 </li>
-<li>Istanbul, Turkey </li>
+<li>June 2020</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Istanbul, Turkey </li>
+<li>Istanbul, Turkey</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2015 to June 2020 </li>
+<li>Sept. 2015 to June 2020</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2021 </li>
+<li>Sept. 2021</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>
-<p>Sept. 2015 to present </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Some <strong>Company</strong>, Software Engineer</h2>
-<ul>
-<li>Sept. 2021 </li>
-</ul>
-<h2>Some <strong>Company</strong>, Software Engineer</h2>
-<ul>
-<li>
-<p>June 2020 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Some <strong>Company</strong>, Software Engineer</h2>
-<ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Some <strong>Company</strong>, Software Engineer</h2>
-<ul>
-<li>Sept. 2015 to June 2020 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Some <strong>Company</strong>, Software Engineer</h2>
-<ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Some <strong>Company</strong>, Software Engineer</h2>
-<ul>
-<li>Sept. 2015 to present </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2015 to present</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>June 2020 </li>
-<li>Istanbul, Turkey </li>
+<li>June 2020</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2021 </li>
+<li>Sept. 2015 to June 2020</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>
-<p>Sept. 2015 to June 2020 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Some <strong>Company</strong>, Software Engineer</h2>
-<ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Some <strong>Company</strong>, Software Engineer</h2>
-<ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Some <strong>Company</strong>, Software Engineer</h2>
-<ul>
-<li>Sept. 2015 to June 2020 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2015 to present</li>
+<li>Istanbul, Turkey</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+</ul>
+<h2>Some <strong>Company</strong>, Software Engineer</h2>
+<ul>
+<li>June 2020</li>
+<li>Istanbul, Turkey</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
+<li>Sept. 2021</li>
+</ul>
+<h2>Some <strong>Company</strong>, Software Engineer</h2>
+<ul>
+<li>Sept. 2015 to June 2020</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Some <strong>Company</strong>, Software Engineer</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Some <strong>Company</strong>, Software Engineer</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+</ul>
+<h2>Some <strong>Company</strong>, Software Engineer</h2>
+<ul>
+<li>Sept. 2015 to June 2020</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Some <strong>Company</strong>, Software Engineer</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Some <strong>Company</strong>, Software Engineer</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Some <strong>Company</strong>, Software Engineer</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Some <strong>Company</strong>, Software Engineer</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
@@ -247,19 +219,19 @@
 <h2>Boğaziçi University, BS in Mechanical Engineering</h2>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Istanbul, Turkey </li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2015 to present </li>
+<li>Sept. 2015 to present</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>June 2020 </li>
+<li>June 2020</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
+<li>Sept. 2021</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
@@ -268,19 +240,19 @@
 </ul>
 <h2>Boğaziçi University, BS in Mechanical Engineering</h2>
 <ul>
-<li>Istanbul, Turkey </li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Boğaziçi University, BS in Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2015 to present </li>
+<li>Sept. 2015 to present</li>
 </ul>
 <h2>Boğaziçi University, BS in Mechanical Engineering</h2>
 <ul>
-<li>June 2020 </li>
+<li>June 2020</li>
 </ul>
 <h2>Boğaziçi University, BS in Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
+<li>Sept. 2021</li>
 </ul>
 <h2>Boğaziçi University, BS in Mechanical Engineering</h2>
 <ul>
@@ -289,353 +261,297 @@
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2015 to present </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2015 to present</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>June 2020 </li>
-<li>Istanbul, Turkey </li>
+<li>June 2020</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Istanbul, Turkey </li>
+<li>Istanbul, Turkey</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2015 to June 2020 </li>
+<li>Sept. 2015 to June 2020</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
+<li>Sept. 2021</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>
-<p>Sept. 2015 to present </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-</ul>
-<h2>Boğaziçi University, Mechanical Engineering</h2>
-<ul>
-<li>
-<p>June 2020 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, Mechanical Engineering</h2>
-<ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2015 to present </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>June 2020 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Istanbul, Turkey </li>
-<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2015 to June 2020 </li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>
-<p>Sept. 2015 to present </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>
-<p>June 2020 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2015 to June 2020 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Boğaziçi University, Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Boğaziçi University, Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2015 to present </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2015 to present</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>June 2020 </li>
-<li>Istanbul, Turkey </li>
+<li>June 2020</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2015 to present</li>
+<li>Istanbul, Turkey</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>June 2020</li>
+<li>Istanbul, Turkey</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2015 to June 2020</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2015 to present</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>June 2020</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
+<li>Sept. 2015 to June 2020</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>
-<p>Sept. 2015 to June 2020 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, Mechanical Engineering</h2>
-<ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2015 to June 2020 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2015 to present </li>
-<li>Istanbul, Turkey </li>
-<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>June 2020 </li>
-<li>Istanbul, Turkey </li>
-<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
-<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>
-<p>Sept. 2015 to June 2020 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Boğaziçi University, Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2015 to June 2020 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2015 to present</li>
+<li>Istanbul, Turkey</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+</ul>
+<h2>Boğaziçi University, Mechanical Engineering</h2>
+<ul>
+<li>June 2020</li>
+<li>Istanbul, Turkey</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+<li>Sept. 2021</li>
 </ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2015 to June 2020 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2015 to June 2020</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
-<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
-<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Boğaziçi University, BS in Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2015 to June 2020</li>
+<li>Istanbul, Turkey</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2015 to present</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>June 2020</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2015 to June 2020</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+</ul>
+<h2>Boğaziçi University, Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2015 to June 2020</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2015 to June 2020</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
@@ -643,19 +559,19 @@
 <h2>My Project</h2>
 <h2>My Project</h2>
 <ul>
-<li>Istanbul, Turkey </li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2015 to present </li>
+<li>Sept. 2015 to present</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>June 2020 </li>
+<li>June 2020</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 </li>
+<li>Sept. 2021</li>
 </ul>
 <h2>My Project</h2>
 <ul>
@@ -664,121 +580,150 @@
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2015 to present - Istanbul, Turkey </li>
+<li>Sept. 2015 to present</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>June 2020 - Istanbul, Turkey </li>
+<li>June 2020</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Istanbul, Turkey - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2015 to June 2020 </li>
+<li>Sept. 2015 to June 2020</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 </li>
+<li>Sept. 2021</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2015 to present - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2015 to present</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 </li>
+<li>Sept. 2021</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>June 2020 - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>June 2020</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2015 to June 2020 - Istanbul, Turkey </li>
+<li>Sept. 2015 to June 2020</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2015 to present - Istanbul, Turkey - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2015 to present</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>June 2020 - Istanbul, Turkey - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>June 2020</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Istanbul, Turkey - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 </li>
+<li>Sept. 2021</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2015 to June 2020 - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2015 to June 2020</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2015 to June 2020 - Istanbul, Turkey - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2015 to June 2020</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Istanbul, Turkey - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Istanbul, Turkey - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Istanbul, Turkey - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h1>One Line Entries</h1>

--- a/tests/testdata/test_markdown_to_html/engineeringresumes_filled.html
+++ b/tests/testdata/test_markdown_to_html/engineeringresumes_filled.html
@@ -47,19 +47,19 @@
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Istanbul, Turkey </li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2015 to present </li>
+<li>Sept. 2015 to present</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>June 2020 </li>
+<li>June 2020</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2021 </li>
+<li>Sept. 2021</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
@@ -68,177 +68,149 @@
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2015 to present </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2015 to present</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>June 2020 </li>
-<li>Istanbul, Turkey </li>
+<li>June 2020</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Istanbul, Turkey </li>
+<li>Istanbul, Turkey</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2015 to June 2020 </li>
+<li>Sept. 2015 to June 2020</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2021 </li>
+<li>Sept. 2021</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>
-<p>Sept. 2015 to present </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Some <strong>Company</strong>, Software Engineer</h2>
-<ul>
-<li>Sept. 2021 </li>
-</ul>
-<h2>Some <strong>Company</strong>, Software Engineer</h2>
-<ul>
-<li>
-<p>June 2020 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Some <strong>Company</strong>, Software Engineer</h2>
-<ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Some <strong>Company</strong>, Software Engineer</h2>
-<ul>
-<li>Sept. 2015 to June 2020 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Some <strong>Company</strong>, Software Engineer</h2>
-<ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Some <strong>Company</strong>, Software Engineer</h2>
-<ul>
-<li>Sept. 2015 to present </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2015 to present</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>June 2020 </li>
-<li>Istanbul, Turkey </li>
+<li>June 2020</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2021 </li>
+<li>Sept. 2015 to June 2020</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>
-<p>Sept. 2015 to June 2020 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Some <strong>Company</strong>, Software Engineer</h2>
-<ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Some <strong>Company</strong>, Software Engineer</h2>
-<ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Some <strong>Company</strong>, Software Engineer</h2>
-<ul>
-<li>Sept. 2015 to June 2020 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2015 to present</li>
+<li>Istanbul, Turkey</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+</ul>
+<h2>Some <strong>Company</strong>, Software Engineer</h2>
+<ul>
+<li>June 2020</li>
+<li>Istanbul, Turkey</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
+<li>Sept. 2021</li>
+</ul>
+<h2>Some <strong>Company</strong>, Software Engineer</h2>
+<ul>
+<li>Sept. 2015 to June 2020</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Some <strong>Company</strong>, Software Engineer</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Some <strong>Company</strong>, Software Engineer</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+</ul>
+<h2>Some <strong>Company</strong>, Software Engineer</h2>
+<ul>
+<li>Sept. 2015 to June 2020</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Some <strong>Company</strong>, Software Engineer</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Some <strong>Company</strong>, Software Engineer</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Some <strong>Company</strong>, Software Engineer</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Some <strong>Company</strong>, Software Engineer</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
@@ -247,19 +219,19 @@
 <h2>Boğaziçi University, BS in Mechanical Engineering</h2>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Istanbul, Turkey </li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2015 to present </li>
+<li>Sept. 2015 to present</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>June 2020 </li>
+<li>June 2020</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
+<li>Sept. 2021</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
@@ -268,19 +240,19 @@
 </ul>
 <h2>Boğaziçi University, BS in Mechanical Engineering</h2>
 <ul>
-<li>Istanbul, Turkey </li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Boğaziçi University, BS in Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2015 to present </li>
+<li>Sept. 2015 to present</li>
 </ul>
 <h2>Boğaziçi University, BS in Mechanical Engineering</h2>
 <ul>
-<li>June 2020 </li>
+<li>June 2020</li>
 </ul>
 <h2>Boğaziçi University, BS in Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
+<li>Sept. 2021</li>
 </ul>
 <h2>Boğaziçi University, BS in Mechanical Engineering</h2>
 <ul>
@@ -289,353 +261,297 @@
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2015 to present </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2015 to present</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>June 2020 </li>
-<li>Istanbul, Turkey </li>
+<li>June 2020</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Istanbul, Turkey </li>
+<li>Istanbul, Turkey</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2015 to June 2020 </li>
+<li>Sept. 2015 to June 2020</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
+<li>Sept. 2021</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>
-<p>Sept. 2015 to present </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-</ul>
-<h2>Boğaziçi University, Mechanical Engineering</h2>
-<ul>
-<li>
-<p>June 2020 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, Mechanical Engineering</h2>
-<ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2015 to present </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>June 2020 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Istanbul, Turkey </li>
-<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2015 to June 2020 </li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>
-<p>Sept. 2015 to present </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>
-<p>June 2020 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2015 to June 2020 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Boğaziçi University, Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Boğaziçi University, Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2015 to present </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2015 to present</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>June 2020 </li>
-<li>Istanbul, Turkey </li>
+<li>June 2020</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2015 to present</li>
+<li>Istanbul, Turkey</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>June 2020</li>
+<li>Istanbul, Turkey</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2015 to June 2020</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2015 to present</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>June 2020</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
+<li>Sept. 2015 to June 2020</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>
-<p>Sept. 2015 to June 2020 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, Mechanical Engineering</h2>
-<ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2015 to June 2020 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2015 to present </li>
-<li>Istanbul, Turkey </li>
-<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>June 2020 </li>
-<li>Istanbul, Turkey </li>
-<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
-<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>
-<p>Sept. 2015 to June 2020 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Boğaziçi University, Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2015 to June 2020 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2015 to present</li>
+<li>Istanbul, Turkey</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+</ul>
+<h2>Boğaziçi University, Mechanical Engineering</h2>
+<ul>
+<li>June 2020</li>
+<li>Istanbul, Turkey</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+<li>Sept. 2021</li>
 </ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2015 to June 2020 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2015 to June 2020</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
-<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
-<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Boğaziçi University, BS in Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2015 to June 2020</li>
+<li>Istanbul, Turkey</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2015 to present</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>June 2020</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2015 to June 2020</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+</ul>
+<h2>Boğaziçi University, Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2015 to June 2020</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2015 to June 2020</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
@@ -643,19 +559,19 @@
 <h2>My Project</h2>
 <h2>My Project</h2>
 <ul>
-<li>Istanbul, Turkey </li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2015 to present </li>
+<li>Sept. 2015 to present</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>June 2020 </li>
+<li>June 2020</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 </li>
+<li>Sept. 2021</li>
 </ul>
 <h2>My Project</h2>
 <ul>
@@ -664,121 +580,150 @@
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2015 to present - Istanbul, Turkey </li>
+<li>Sept. 2015 to present</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>June 2020 - Istanbul, Turkey </li>
+<li>June 2020</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Istanbul, Turkey - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2015 to June 2020 </li>
+<li>Sept. 2015 to June 2020</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 </li>
+<li>Sept. 2021</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2015 to present - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2015 to present</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 </li>
+<li>Sept. 2021</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>June 2020 - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>June 2020</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2015 to June 2020 - Istanbul, Turkey </li>
+<li>Sept. 2015 to June 2020</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2015 to present - Istanbul, Turkey - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2015 to present</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>June 2020 - Istanbul, Turkey - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>June 2020</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Istanbul, Turkey - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 </li>
+<li>Sept. 2021</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2015 to June 2020 - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2015 to June 2020</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2015 to June 2020 - Istanbul, Turkey - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2015 to June 2020</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Istanbul, Turkey - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Istanbul, Turkey - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Istanbul, Turkey - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h1>One Line Entries</h1>

--- a/tests/testdata/test_markdown_to_html/moderncv_filled.html
+++ b/tests/testdata/test_markdown_to_html/moderncv_filled.html
@@ -47,19 +47,19 @@
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Istanbul, Turkey </li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2015 to present </li>
+<li>Sept. 2015 to present</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>June 2020 </li>
+<li>June 2020</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2021 </li>
+<li>Sept. 2021</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
@@ -68,177 +68,149 @@
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2015 to present </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2015 to present</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>June 2020 </li>
-<li>Istanbul, Turkey </li>
+<li>June 2020</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Istanbul, Turkey </li>
+<li>Istanbul, Turkey</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2015 to June 2020 </li>
+<li>Sept. 2015 to June 2020</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2021 </li>
+<li>Sept. 2021</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>
-<p>Sept. 2015 to present </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Some <strong>Company</strong>, Software Engineer</h2>
-<ul>
-<li>Sept. 2021 </li>
-</ul>
-<h2>Some <strong>Company</strong>, Software Engineer</h2>
-<ul>
-<li>
-<p>June 2020 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Some <strong>Company</strong>, Software Engineer</h2>
-<ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Some <strong>Company</strong>, Software Engineer</h2>
-<ul>
-<li>Sept. 2015 to June 2020 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Some <strong>Company</strong>, Software Engineer</h2>
-<ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Some <strong>Company</strong>, Software Engineer</h2>
-<ul>
-<li>Sept. 2015 to present </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2015 to present</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>June 2020 </li>
-<li>Istanbul, Turkey </li>
+<li>June 2020</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2021 </li>
+<li>Sept. 2015 to June 2020</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>
-<p>Sept. 2015 to June 2020 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Some <strong>Company</strong>, Software Engineer</h2>
-<ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Some <strong>Company</strong>, Software Engineer</h2>
-<ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Some <strong>Company</strong>, Software Engineer</h2>
-<ul>
-<li>Sept. 2015 to June 2020 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2015 to present</li>
+<li>Istanbul, Turkey</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+</ul>
+<h2>Some <strong>Company</strong>, Software Engineer</h2>
+<ul>
+<li>June 2020</li>
+<li>Istanbul, Turkey</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
+<li>Sept. 2021</li>
+</ul>
+<h2>Some <strong>Company</strong>, Software Engineer</h2>
+<ul>
+<li>Sept. 2015 to June 2020</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Some <strong>Company</strong>, Software Engineer</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Some <strong>Company</strong>, Software Engineer</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+</ul>
+<h2>Some <strong>Company</strong>, Software Engineer</h2>
+<ul>
+<li>Sept. 2015 to June 2020</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Some <strong>Company</strong>, Software Engineer</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Some <strong>Company</strong>, Software Engineer</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Some <strong>Company</strong>, Software Engineer</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Some <strong>Company</strong>, Software Engineer</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
@@ -247,19 +219,19 @@
 <h2>Boğaziçi University, BS in Mechanical Engineering</h2>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Istanbul, Turkey </li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2015 to present </li>
+<li>Sept. 2015 to present</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>June 2020 </li>
+<li>June 2020</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
+<li>Sept. 2021</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
@@ -268,19 +240,19 @@
 </ul>
 <h2>Boğaziçi University, BS in Mechanical Engineering</h2>
 <ul>
-<li>Istanbul, Turkey </li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Boğaziçi University, BS in Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2015 to present </li>
+<li>Sept. 2015 to present</li>
 </ul>
 <h2>Boğaziçi University, BS in Mechanical Engineering</h2>
 <ul>
-<li>June 2020 </li>
+<li>June 2020</li>
 </ul>
 <h2>Boğaziçi University, BS in Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
+<li>Sept. 2021</li>
 </ul>
 <h2>Boğaziçi University, BS in Mechanical Engineering</h2>
 <ul>
@@ -289,353 +261,297 @@
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2015 to present </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2015 to present</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>June 2020 </li>
-<li>Istanbul, Turkey </li>
+<li>June 2020</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Istanbul, Turkey </li>
+<li>Istanbul, Turkey</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2015 to June 2020 </li>
+<li>Sept. 2015 to June 2020</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
+<li>Sept. 2021</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>
-<p>Sept. 2015 to present </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-</ul>
-<h2>Boğaziçi University, Mechanical Engineering</h2>
-<ul>
-<li>
-<p>June 2020 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, Mechanical Engineering</h2>
-<ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2015 to present </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>June 2020 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Istanbul, Turkey </li>
-<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2015 to June 2020 </li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>
-<p>Sept. 2015 to present </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>
-<p>June 2020 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2015 to June 2020 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Boğaziçi University, Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Boğaziçi University, Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2015 to present </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2015 to present</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>June 2020 </li>
-<li>Istanbul, Turkey </li>
+<li>June 2020</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2015 to present</li>
+<li>Istanbul, Turkey</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>June 2020</li>
+<li>Istanbul, Turkey</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2015 to June 2020</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2015 to present</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>June 2020</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
+<li>Sept. 2015 to June 2020</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>
-<p>Sept. 2015 to June 2020 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, Mechanical Engineering</h2>
-<ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2015 to June 2020 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2015 to present </li>
-<li>Istanbul, Turkey </li>
-<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>June 2020 </li>
-<li>Istanbul, Turkey </li>
-<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
-<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>
-<p>Sept. 2015 to June 2020 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Boğaziçi University, Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2015 to June 2020 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2015 to present</li>
+<li>Istanbul, Turkey</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+</ul>
+<h2>Boğaziçi University, Mechanical Engineering</h2>
+<ul>
+<li>June 2020</li>
+<li>Istanbul, Turkey</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+<li>Sept. 2021</li>
 </ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2015 to June 2020 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2015 to June 2020</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
-<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
-<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Boğaziçi University, BS in Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2015 to June 2020</li>
+<li>Istanbul, Turkey</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2015 to present</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>June 2020</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2015 to June 2020</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+</ul>
+<h2>Boğaziçi University, Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2015 to June 2020</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2015 to June 2020</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
@@ -643,19 +559,19 @@
 <h2>My Project</h2>
 <h2>My Project</h2>
 <ul>
-<li>Istanbul, Turkey </li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2015 to present </li>
+<li>Sept. 2015 to present</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>June 2020 </li>
+<li>June 2020</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 </li>
+<li>Sept. 2021</li>
 </ul>
 <h2>My Project</h2>
 <ul>
@@ -664,121 +580,150 @@
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2015 to present - Istanbul, Turkey </li>
+<li>Sept. 2015 to present</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>June 2020 - Istanbul, Turkey </li>
+<li>June 2020</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Istanbul, Turkey - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2015 to June 2020 </li>
+<li>Sept. 2015 to June 2020</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 </li>
+<li>Sept. 2021</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2015 to present - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2015 to present</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 </li>
+<li>Sept. 2021</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>June 2020 - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>June 2020</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2015 to June 2020 - Istanbul, Turkey </li>
+<li>Sept. 2015 to June 2020</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2015 to present - Istanbul, Turkey - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2015 to present</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>June 2020 - Istanbul, Turkey - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>June 2020</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Istanbul, Turkey - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 </li>
+<li>Sept. 2021</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2015 to June 2020 - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2015 to June 2020</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2015 to June 2020 - Istanbul, Turkey - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2015 to June 2020</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Istanbul, Turkey - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Istanbul, Turkey - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Istanbul, Turkey - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h1>One Line Entries</h1>

--- a/tests/testdata/test_markdown_to_html/sb2nov_filled.html
+++ b/tests/testdata/test_markdown_to_html/sb2nov_filled.html
@@ -47,19 +47,19 @@
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Istanbul, Turkey </li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2015 to present </li>
+<li>Sept. 2015 to present</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>June 2020 </li>
+<li>June 2020</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2021 </li>
+<li>Sept. 2021</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
@@ -68,177 +68,149 @@
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2015 to present </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2015 to present</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>June 2020 </li>
-<li>Istanbul, Turkey </li>
+<li>June 2020</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Istanbul, Turkey </li>
+<li>Istanbul, Turkey</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2015 to June 2020 </li>
+<li>Sept. 2015 to June 2020</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2021 </li>
+<li>Sept. 2021</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>
-<p>Sept. 2015 to present </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Some <strong>Company</strong>, Software Engineer</h2>
-<ul>
-<li>Sept. 2021 </li>
-</ul>
-<h2>Some <strong>Company</strong>, Software Engineer</h2>
-<ul>
-<li>
-<p>June 2020 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Some <strong>Company</strong>, Software Engineer</h2>
-<ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Some <strong>Company</strong>, Software Engineer</h2>
-<ul>
-<li>Sept. 2015 to June 2020 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Some <strong>Company</strong>, Software Engineer</h2>
-<ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Some <strong>Company</strong>, Software Engineer</h2>
-<ul>
-<li>Sept. 2015 to present </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2015 to present</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>June 2020 </li>
-<li>Istanbul, Turkey </li>
+<li>June 2020</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2021 </li>
+<li>Sept. 2015 to June 2020</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>
-<p>Sept. 2015 to June 2020 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Some <strong>Company</strong>, Software Engineer</h2>
-<ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Some <strong>Company</strong>, Software Engineer</h2>
-<ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Some <strong>Company</strong>, Software Engineer</h2>
-<ul>
-<li>Sept. 2015 to June 2020 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2015 to present</li>
+<li>Istanbul, Turkey</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+</ul>
+<h2>Some <strong>Company</strong>, Software Engineer</h2>
+<ul>
+<li>June 2020</li>
+<li>Istanbul, Turkey</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
+<li>Sept. 2021</li>
+</ul>
+<h2>Some <strong>Company</strong>, Software Engineer</h2>
+<ul>
+<li>Sept. 2015 to June 2020</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Some <strong>Company</strong>, Software Engineer</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Some <strong>Company</strong>, Software Engineer</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Some <strong>Company</strong>, Software Engineer</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+</ul>
+<h2>Some <strong>Company</strong>, Software Engineer</h2>
+<ul>
+<li>Sept. 2015 to June 2020</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Some <strong>Company</strong>, Software Engineer</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Some <strong>Company</strong>, Software Engineer</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Some <strong>Company</strong>, Software Engineer</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Some <strong>Company</strong>, Software Engineer</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
@@ -247,19 +219,19 @@
 <h2>Boğaziçi University, BS in Mechanical Engineering</h2>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Istanbul, Turkey </li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2015 to present </li>
+<li>Sept. 2015 to present</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>June 2020 </li>
+<li>June 2020</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
+<li>Sept. 2021</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
@@ -268,19 +240,19 @@
 </ul>
 <h2>Boğaziçi University, BS in Mechanical Engineering</h2>
 <ul>
-<li>Istanbul, Turkey </li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Boğaziçi University, BS in Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2015 to present </li>
+<li>Sept. 2015 to present</li>
 </ul>
 <h2>Boğaziçi University, BS in Mechanical Engineering</h2>
 <ul>
-<li>June 2020 </li>
+<li>June 2020</li>
 </ul>
 <h2>Boğaziçi University, BS in Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
+<li>Sept. 2021</li>
 </ul>
 <h2>Boğaziçi University, BS in Mechanical Engineering</h2>
 <ul>
@@ -289,353 +261,297 @@
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2015 to present </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2015 to present</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>June 2020 </li>
-<li>Istanbul, Turkey </li>
+<li>June 2020</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Istanbul, Turkey </li>
+<li>Istanbul, Turkey</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2015 to June 2020 </li>
+<li>Sept. 2015 to June 2020</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
+<li>Sept. 2021</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>
-<p>Sept. 2015 to present </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-</ul>
-<h2>Boğaziçi University, Mechanical Engineering</h2>
-<ul>
-<li>
-<p>June 2020 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, Mechanical Engineering</h2>
-<ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2015 to present </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>June 2020 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Istanbul, Turkey </li>
-<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2015 to June 2020 </li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>
-<p>Sept. 2015 to present </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>
-<p>June 2020 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2015 to June 2020 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Boğaziçi University, Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Boğaziçi University, Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2015 to present </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2015 to present</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>June 2020 </li>
-<li>Istanbul, Turkey </li>
+<li>June 2020</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2015 to present</li>
+<li>Istanbul, Turkey</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>June 2020</li>
+<li>Istanbul, Turkey</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2015 to June 2020</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2015 to present</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>June 2020</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
+<li>Sept. 2015 to June 2020</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>
-<p>Sept. 2015 to June 2020 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, Mechanical Engineering</h2>
-<ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2015 to June 2020 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2015 to present </li>
-<li>Istanbul, Turkey </li>
-<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>June 2020 </li>
-<li>Istanbul, Turkey </li>
-<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
-<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>
-<p>Sept. 2015 to June 2020 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Boğaziçi University, Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2015 to June 2020 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2015 to present</li>
+<li>Istanbul, Turkey</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+</ul>
+<h2>Boğaziçi University, Mechanical Engineering</h2>
+<ul>
+<li>June 2020</li>
+<li>Istanbul, Turkey</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+<li>Sept. 2021</li>
 </ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2015 to June 2020 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2015 to June 2020</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
-<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
-<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
-<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
-</ul>
-<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
-<ul>
-<li>
-<p>Sept. 2021 </p>
-</li>
-<li>
-<p>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</p>
-</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Boğaziçi University, Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>Boğaziçi University, BS in Mechanical Engineering</h2>
 <ul>
-<li>Sept. 2021 </li>
-<li>Istanbul, Turkey </li>
+<li>Sept. 2015 to June 2020</li>
+<li>Istanbul, Turkey</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2015 to present</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>June 2020</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2015 to June 2020</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+</ul>
+<h2>Boğaziçi University, Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2015 to June 2020</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2015 to June 2020</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
+</ul>
+<h2>Boğaziçi University, BS in Mechanical Engineering</h2>
+<ul>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 <li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
@@ -643,19 +559,19 @@
 <h2>My Project</h2>
 <h2>My Project</h2>
 <ul>
-<li>Istanbul, Turkey </li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2015 to present </li>
+<li>Sept. 2015 to present</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>June 2020 </li>
+<li>June 2020</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 </li>
+<li>Sept. 2021</li>
 </ul>
 <h2>My Project</h2>
 <ul>
@@ -664,121 +580,150 @@
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2015 to present - Istanbul, Turkey </li>
+<li>Sept. 2015 to present</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>June 2020 - Istanbul, Turkey </li>
+<li>June 2020</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Istanbul, Turkey - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2015 to June 2020 </li>
+<li>Sept. 2015 to June 2020</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 </li>
+<li>Sept. 2021</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2015 to present - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2015 to present</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 </li>
+<li>Sept. 2021</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>June 2020 - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>June 2020</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2015 to June 2020 - Istanbul, Turkey </li>
+<li>Sept. 2015 to June 2020</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2015 to present - Istanbul, Turkey - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2015 to present</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>June 2020 - Istanbul, Turkey - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>June 2020</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Istanbul, Turkey - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 </li>
+<li>Sept. 2021</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2015 to June 2020 - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2015 to June 2020</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Istanbul, Turkey </li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2015 to June 2020 - Istanbul, Turkey - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2015 to June 2020</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Istanbul, Turkey - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Istanbul, Turkey - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2021</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h2>My Project</h2>
 <ul>
-<li>Sept. 2021 - Istanbul, Turkey - Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
+<li>Sept. 2021</li>
+<li>Istanbul, Turkey</li>
+<li>Did <em>this</em> and this is a <strong>bold</strong> <a href="https://example.com">link</a>. But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.</li>
 <li>Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.</li>
 </ul>
 <h1>One Line Entries</h1>


### PR DESCRIPTION
I've faced an issue with the new lines in markdown during rendering of my CV. Found that in case if optional fields aren't provided there were redundant new lines. Also project section missed new line after dates.