### PR TITLE
Add StackOverflow to list of social networks

### DIFF
--- a/rendercv/data_models.py
+++ b/rendercv/data_models.py
@@ -831,7 +831,13 @@ class SocialNetwork(RenderCVBaseModel):
     """This class is the data model of a social network."""
 
     network: Literal[
-        "LinkedIn", "GitHub", "Instagram", "Orcid", "Mastodon", "Twitter"
+        "LinkedIn",
+        "GitHub",
+        "Instagram",
+        "Orcid",
+        "Mastodon",
+        "Twitter",
+        "StackOverflow",
     ] = pydantic.Field(
         title="Social Network",
         description="The social network name.",
@@ -871,6 +877,9 @@ class SocialNetwork(RenderCVBaseModel):
             # split domain and username
             dummy, username, domain = self.username.split("@")
             url = f"https://{domain}/@{username}"
+        elif self.network == "StackOverflow":
+            user_id, username = self.username.split("/")
+            url = f"https://stackoverflow.com/users/{user_id}/{username}"
         else:
             url_dictionary = {
                 "LinkedIn": "https://linkedin.com/in/",
@@ -983,18 +992,22 @@ class CurriculumVitae(RenderCVBaseModel):
                 "Instagram": "\\faInstagram",
                 "Mastodon": "\\faMastodon",
                 "Orcid": "\\faOrcid",
+                "StackOverflow": "\\faStackOverflow",
                 "Twitter": "\\faTwitter",
             }
             for social_network in self.social_networks:
                 clean_url = social_network.url.replace("https://", "").rstrip("/")
-                connections.append(
-                    {
-                        "latex_icon": icon_dictionary[social_network.network],
-                        "url": social_network.url,
-                        "clean_url": clean_url,
-                        "placeholder": social_network.username,
-                    }
-                )
+                connection = {
+                    "latex_icon": icon_dictionary[social_network.network],
+                    "url": social_network.url,
+                    "clean_url": clean_url,
+                    "placeholder": social_network.username,
+                }
+
+                if social_network.network == "StackOverflow":
+                    username = social_network.username.split("/")[1]
+                    connection["placeholder"] = username
+                connections.append(connection)
 
         return connections
 

--- a/tests/test_data_models.py
+++ b/tests/test_data_models.py
@@ -426,6 +426,11 @@ def test_invalid_social_networks(network, username):
         ("Orcid", "myusername", "https://orcid.org/myusername"),
         ("Twitter", "myusername", "https://twitter.com/myusername"),
         ("Mastodon", "@myusername@test.org", "https://test.org/@myusername"),
+        (
+            "StackOverflow",
+            "4567/myusername",
+            "https://stackoverflow.com/users/4567/myusername",
+        ),
     ],
 )
 def test_social_network_url(network, username, expected_url):


### PR DESCRIPTION
Thank you for building this amazing tool 🙏 

I thought it'd be great if folks could add their StackOverflow profiles in the header section. This PR adds support for StackOverflow profiles

A SO profile URL looks like this

```
https://stackoverflow.com/users/{id}/{username}
```

We ask the user to grab the `{id}/{username}` part and add it to the `social_networks` section in the main YAML

```
  social_networks:
    - network: LinkedIn
      username: iamprithaj
    - network: GitHub
      username: prithajnath
    - network: StackOverflow
      username: 3007613/prithajnath

```

It will be rendered like this (`sb2nov` theme)
<img width="269" alt="Screenshot 2024-05-23 at 1 27 01 AM" src="https://github.com/sinaatalay/rendercv/assets/8249341/e59c4a14-8f77-4aed-8a68-852f7b209493">


