### PR TITLE
Fix fonts in Engineeringresumes theme

### DIFF
--- a/rendercv/themes/engineeringresumes/Preamble.j2.tex
+++ b/rendercv/themes/engineeringresumes/Preamble.j2.tex
@@ -40,19 +40,10 @@
     \pdfgentounicode=1
     \usepackage[T1]{fontenc}
     \usepackage[utf8]{inputenc}
-    \usepackage{lmodern}
 \fi
 
-((* if design.font == "Latin Modern Serif" *))
-
-((* elif design.font == "Latin Modern Sans Serif" *))
-\renewcommand{\familydefault}{\sfdefault}
-((* elif design.font == "Latin Modern Mono" *))
-\renewcommand{\familydefault}{\ttdefault}
-((* elif design.font == "Source Sans 3" *))
-\usepackage[default, type1]{sourcesanspro} 
-((* elif design.font == "Charter" *))
-\usepackage{charter}
+((* if design.font == "XCharter" *))
+\usepackage{XCharter}
 ((* endif *))
 
 % Some settings:

--- a/rendercv/themes/engineeringresumes/__init__.py
+++ b/rendercv/themes/engineeringresumes/__init__.py
@@ -101,11 +101,7 @@ class EngineeringresumesThemeOptions(ThemeOptions):
 
     theme: Literal["engineeringresumes"]
     font: Literal[
-        "Latin Modern Serif",
-        "Latin Modern Sans Serif",
-        "Latin Modern Mono",
-        "Source Sans 3",
-        "Charter",
+        "XCharter",
     ] = pydantic.Field(
         default="Charter",
         title="Font",


### PR DESCRIPTION
- Update Bitstream Charter to [**XCharter**](https://ftp.snt.utwente.nl/pub/software/tex/fonts/xcharter/doc/xcharter-doc.pdf)

> The XCharter fonts are extensions of the Bitstream Charter fonts, adding oldstyle figures, superior figures and small caps in all styles.

- Remove unwanted fonts: ~~Latin Modern Serif, Latin Modern Sans Serif, Latin Modern Mono, Source Sans 3~~