### PR TITLE
Add Markdown Extra extension

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -97,6 +97,7 @@ nav:
 
 markdown_extensions:
   # see https://facelessuser.github.io/pymdown-extensions/extensions/inlinehilite/ for more pymdownx info
+  - extra # Enable the Markdown Extra extensions
   - pymdownx.highlight:
       anchor_linenums: true
       line_spans: __span

--- a/rendercv/renderer/renderer.py
+++ b/rendercv/renderer/renderer.py
@@ -320,9 +320,11 @@ def render_an_html_from_markdown(markdown_file_path: pathlib.Path) -> pathlib.Pa
     if not markdown_file_path.is_file():
         raise FileNotFoundError(f"The file {markdown_file_path} doesn't exist!")
 
-    # Convert the markdown file to HTML:
+    # Convert the markdown file to HTML, supporting Markdown Extra:
     markdown_text = markdown_file_path.read_text(encoding="utf-8")
-    html_body = markdown.markdown(markdown_text, extensions=["toc", "extra"]) # uses the TOC and Markdown Extra extensions
+    html_body = markdown.markdown(
+        markdown_text, extensions=["extra"]
+    )
 
     # Get the title of the markdown content:
     title = re.search(r"# (.*)\n", markdown_text)

--- a/rendercv/renderer/renderer.py
+++ b/rendercv/renderer/renderer.py
@@ -322,7 +322,7 @@ def render_an_html_from_markdown(markdown_file_path: pathlib.Path) -> pathlib.Pa
 
     # Convert the markdown file to HTML:
     markdown_text = markdown_file_path.read_text(encoding="utf-8")
-    html_body = markdown.markdown(markdown_text)
+    html_body = markdown.markdown(markdown_text, extensions=["toc", "extra"]) # uses the TOC and Markdown Extra extensions
 
     # Get the title of the markdown content:
     title = re.search(r"# (.*)\n", markdown_text)

--- a/rendercv/themes/main.j2.html
+++ b/rendercv/themes/main.j2.html
@@ -12,6 +12,9 @@
         href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.5.1/github-markdown-light.min.css"
         integrity="sha512-Pmhg2i/F7+5+7SsdoUqKeH7UAZoVMYb1sxGOoJ0jWXAEHP0XV2H4CITyK267eHWp2jpj7rtqWNkmEOw1tNyYpg=="
         crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.2.2/es5/tex-mml-chtml.min.js"
+        integrity="sha512-6FaAxxHuKuzaGHWnV00ftWqP3luSBRSopnNAA2RvQH1fOfnF/A1wOfiUWF7cLIOFcfb1dEhXwo5VG3DAisocRw=="
+        crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <style>
         .markdown-body {
             box-sizing: border-box;

--- a/rendercv/themes/main.j2.html
+++ b/rendercv/themes/main.j2.html
@@ -12,9 +12,6 @@
         href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.5.1/github-markdown-light.min.css"
         integrity="sha512-Pmhg2i/F7+5+7SsdoUqKeH7UAZoVMYb1sxGOoJ0jWXAEHP0XV2H4CITyK267eHWp2jpj7rtqWNkmEOw1tNyYpg=="
         crossorigin="anonymous" referrerpolicy="no-referrer" />
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.2.2/es5/tex-mml-chtml.min.js"
-        integrity="sha512-6FaAxxHuKuzaGHWnV00ftWqP3luSBRSopnNAA2RvQH1fOfnF/A1wOfiUWF7cLIOFcfb1dEhXwo5VG3DAisocRw=="
-        crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <style>
         .markdown-body {
             box-sizing: border-box;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -426,9 +426,8 @@ def run_a_function_and_check_if_output_is_the_same_as_reference(
         generate_reference_files_function: Optional[typing.Callable] = None,
         **kwargs,
     ):
-        output_is_a_single_file = output_file_name is not None
-        if output_is_a_single_file:
-            output_file_path = tmp_path / output_file_name
+        output_file_path = tmp_path / output_file_name if output_file_name else None
+        output_is_a_single_file = output_file_path is not None
 
         reference_directory_path: pathlib.Path = specific_testdata_directory_path
         reference_file_or_directory_path = (


### PR DESCRIPTION
**Feature Description:**
Add Markdown Extra support to the RenderCV renderer. This enhancement would significantly improve the flexibility and styling options for the generated HTML output from CV templates, enabling rendercv to build not just a PDF resumé, but also a personal profile webpage in the same pipeline. 

**Use Cases:**

1. Enhanced Styling: By allowing the use of classes and IDs in Markdown, users can apply custom CSS styles to specific sections of their CVs, resulting in a more personalized and visually appealing presentation.
2. Improved Section Identification: The ability to assign IDs to sections would facilitate easier navigation within the document, especially for longer CVs, improving the overall user experience. This also enables the use of a nav-menu on the page.
3. Better Integration with CSS Frameworks: Many users leverage CSS frameworks that rely on classes for styling. Enabling this feature would allow users to seamlessly integrate their CVs with frameworks like Bootstrap or Tailwind CSS.

**Proposed Solution:**
To implement this feature, I suggest integrating the Markdown Extra extension into the existing rendering pipeline. 