### PR TITLE
Add support for LaTeX math expressions in HTML output

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -97,6 +97,7 @@ nav:
 
 markdown_extensions:
   # see https://facelessuser.github.io/pymdown-extensions/extensions/inlinehilite/ for more pymdownx info
+  - extra # Enable the Markdown Extra extensions
   - pymdownx.highlight:
       anchor_linenums: true
       line_spans: __span

--- a/rendercv/renderer/renderer.py
+++ b/rendercv/renderer/renderer.py
@@ -320,9 +320,11 @@ def render_an_html_from_markdown(markdown_file_path: pathlib.Path) -> pathlib.Pa
     if not markdown_file_path.is_file():
         raise FileNotFoundError(f"The file {markdown_file_path} doesn't exist!")
 
-    # Convert the markdown file to HTML:
+    # Convert the markdown file to HTML, supporting Markdown Extra:
     markdown_text = markdown_file_path.read_text(encoding="utf-8")
-    html_body = markdown.markdown(markdown_text, extensions=["toc", "extra"]) # uses the TOC and Markdown Extra extensions
+    html_body = markdown.markdown(
+        markdown_text, extensions=["extra"]
+    )
 
     # Get the title of the markdown content:
     title = re.search(r"# (.*)\n", markdown_text)

--- a/rendercv/renderer/renderer.py
+++ b/rendercv/renderer/renderer.py
@@ -322,7 +322,7 @@ def render_an_html_from_markdown(markdown_file_path: pathlib.Path) -> pathlib.Pa
 
     # Convert the markdown file to HTML:
     markdown_text = markdown_file_path.read_text(encoding="utf-8")
-    html_body = markdown.markdown(markdown_text)
+    html_body = markdown.markdown(markdown_text, extensions=["toc", "extra"]) # uses the TOC and Markdown Extra extensions
 
     # Get the title of the markdown content:
     title = re.search(r"# (.*)\n", markdown_text)

--- a/rendercv/themes/main.j2.html
+++ b/rendercv/themes/main.j2.html
@@ -12,6 +12,9 @@
         href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.5.1/github-markdown-light.min.css"
         integrity="sha512-Pmhg2i/F7+5+7SsdoUqKeH7UAZoVMYb1sxGOoJ0jWXAEHP0XV2H4CITyK267eHWp2jpj7rtqWNkmEOw1tNyYpg=="
         crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.2.2/es5/tex-mml-chtml.min.js"
+        integrity="sha512-6FaAxxHuKuzaGHWnV00ftWqP3luSBRSopnNAA2RvQH1fOfnF/A1wOfiUWF7cLIOFcfb1dEhXwo5VG3DAisocRw=="
+        crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <style>
         .markdown-body {
             box-sizing: border-box;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -426,9 +426,8 @@ def run_a_function_and_check_if_output_is_the_same_as_reference(
         generate_reference_files_function: Optional[typing.Callable] = None,
         **kwargs,
     ):
-        output_is_a_single_file = output_file_name is not None
-        if output_is_a_single_file:
-            output_file_path = tmp_path / output_file_name
+        output_file_path = tmp_path / output_file_name if output_file_name else None
+        output_is_a_single_file = output_file_path is not None
 
         reference_directory_path: pathlib.Path = specific_testdata_directory_path
         reference_file_or_directory_path = (


### PR DESCRIPTION
**Issue Description**
Currently, the HTML output displays e.g. the example entry
```
Built an app to compute the similarity of all methods
in a codebase, reducing the time from $$\mathcal{O}(n^2)$$
to $$\mathcal{O}(n \log n)$$
```
as a literal, without rendering the math expression. 

**Suggested change**
By adding Mathjax to the document via the Cloudflare CDN, LaTeX and LaTeX math expressions get parsed correctly if the CDN is reachable. 