### PR TITLE
Support substitutions in output_folder_name

### DIFF
--- a/rendercv/data/models/computers.py
+++ b/rendercv/data/models/computers.py
@@ -89,11 +89,8 @@ def format_date(date: Date, date_style: Optional[str] = None) -> str:
     return date_string  # type: ignore
 
 
-def convert_string_to_path(value: str) -> pathlib.Path:
-    """Converts a string to a `pathlib.Path` object by replacing the placeholders
-    with the corresponding values. If the path is not an absolute path, it is
-    converted to an absolute path by prepending the current working directory.
-    """
+def replace_placeholders(value: str) -> str:
+    """Replaces the placeholders in a string with the corresponding values."""
     name = curriculum_vitae["name"]  # Curriculum Vitae owner's name
     full_month_names = LOCALE_CATALOG["full_names_of_months"]
     short_month_names = LOCALE_CATALOG["abbreviations_for_months"]
@@ -119,6 +116,16 @@ def convert_string_to_path(value: str) -> pathlib.Path:
 
     for placeholder, placeholder_value in placeholders.items():
         value = value.replace(placeholder, placeholder_value)
+
+    return value
+
+
+def convert_string_to_path(value: str) -> pathlib.Path:
+    """Converts a string to a `pathlib.Path` object by replacing the placeholders
+    with the corresponding values. If the path is not an absolute path, it is
+    converted to an absolute path by prepending the current working directory.
+    """
+    value = replace_placeholders(value)
 
     return pathlib.Path(value).absolute()
 

--- a/rendercv/data/models/rendercv_settings.py
+++ b/rendercv/data/models/rendercv_settings.py
@@ -9,7 +9,7 @@ from typing import Optional
 import pydantic
 
 from .base import RenderCVBaseModelWithoutExtraKeys
-from .computers import convert_string_to_path
+from .computers import convert_string_to_path, replace_placeholders
 
 file_path_placeholder_description = (
     "The following placeholders can be used:\n- FULL_MONTH_NAME: Full name of the"
@@ -127,6 +127,15 @@ class RenderCommandSettings(RenderCVBaseModelWithoutExtraKeys):
             " default value is False."
         ),
     )
+
+    @pydantic.field_validator(
+        "output_folder_name",
+        mode="before",
+    )
+    @classmethod
+    def replace_placeholders(cls, value: str) -> str:
+        """Replaces the placeholders in a string with the corresponding values."""
+        return replace_placeholders(value)
 
     @pydantic.field_validator(
         "pdf_path",

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -848,3 +848,7 @@ def test_render_command_settings_placeholders(path_name, expected_value):
     )
 
     assert render_command_settings.pdf_path.name == expected_value  # type: ignore
+    assert render_command_settings.latex_path.name == expected_value  # type: ignore
+    assert render_command_settings.html_path.name == expected_value  # type: ignore
+    assert render_command_settings.markdown_path.name == expected_value  # type: ignore
+    assert render_command_settings.output_folder_name == expected_value


### PR DESCRIPTION
Fixes #207. Also adds placeholder tests for some additional fields which were not previously tested, but still worked.

After adding the test, but before the fix:

```
========================================================================================================================================= short test summary info =========================================================================================================================================
SKIPPED [1] tests/test_data.py:162: We should start using this when we start to use branches for each version.
XFAIL tests/test_renderer.py::test_latex_file_revert_nested_latex_style_commands_method_challenging_ones[\\textbf{This is a \\textbf{nested} bold \\textbf{text}.}-\\textbf{This is a \\textnormal{nested} bold \\textnormal{text}.}] - The current implementation of revert_nested_latex_style_commands method does not handle the challenging cases in the test cases below.
XFAIL tests/test_renderer.py::test_latex_file_revert_nested_latex_style_commands_method_challenging_ones[\\textit{This \\textit{is} a \\textbf{n\\textit{ested}} underlined \\textit{text}.}-\\textit{This \\textnormal{is} a \\textbf{n\\textnormal{ested}} underlined \\textnormal{text}.}] - The current implementation of revert_nested_latex_style_commands method does not handle the challenging cases in the test cases below.
FAILED tests/test_data.py::test_render_command_settings_placeholders[NAME_IN_SNAKE_CASE-John_Doe] - AssertionError: assert 'NAME_IN_SNAKE_CASE' == 'John_Doe'
FAILED tests/test_data.py::test_render_command_settings_placeholders[NAME_IN_LOWER_SNAKE_CASE-john_doe] - AssertionError: assert 'NAME_IN_LOWER_SNAKE_CASE' == 'john_doe'
FAILED tests/test_data.py::test_render_command_settings_placeholders[NAME_IN_UPPER_SNAKE_CASE-JOHN_DOE] - AssertionError: assert 'NAME_IN_UPPER_SNAKE_CASE' == 'JOHN_DOE'
FAILED tests/test_data.py::test_render_command_settings_placeholders[NAME_IN_KEBAB_CASE-John-Doe] - AssertionError: assert 'NAME_IN_KEBAB_CASE' == 'John-Doe'
FAILED tests/test_data.py::test_render_command_settings_placeholders[NAME_IN_LOWER_KEBAB_CASE-john-doe] - AssertionError: assert 'NAME_IN_LOWER_KEBAB_CASE' == 'john-doe'
FAILED tests/test_data.py::test_render_command_settings_placeholders[NAME_IN_UPPER_KEBAB_CASE-JOHN-DOE] - AssertionError: assert 'NAME_IN_UPPER_KEBAB_CASE' == 'JOHN-DOE'
FAILED tests/test_data.py::test_render_command_settings_placeholders[NAME-John Doe] - AssertionError: assert 'NAME' == 'John Doe'
FAILED tests/test_data.py::test_render_command_settings_placeholders[FULL_MONTH_NAME-January] - AssertionError: assert 'FULL_MONTH_NAME' == 'January'
FAILED tests/test_data.py::test_render_command_settings_placeholders[MONTH_ABBREVIATION-Jan] - AssertionError: assert 'MONTH_ABBREVIATION' == 'Jan'
FAILED tests/test_data.py::test_render_command_settings_placeholders[MONTH-1] - AssertionError: assert 'MONTH' == '1'
FAILED tests/test_data.py::test_render_command_settings_placeholders[MONTH_IN_TWO_DIGITS-01] - AssertionError: assert 'MONTH_IN_TWO_DIGITS' == '01'
FAILED tests/test_data.py::test_render_command_settings_placeholders[YEAR-2024] - AssertionError: assert 'YEAR' == '2024'
FAILED tests/test_data.py::test_render_command_settings_placeholders[YEAR_IN_TWO_DIGITS-24] - AssertionError: assert 'YEAR_IN_TWO_DIGITS' == '24'
============================================================================================================== 13 failed, 367 passed, 1 skipped, 2 xfailed, 68 warnings in 80.07s (0:01:20) ===============================================================================================================
```

After the fix:
```
========================================================================================================================================= short test summary info =========================================================================================================================================
SKIPPED [1] tests/test_data.py:162: We should start using this when we start to use branches for each version.
XFAIL tests/test_renderer.py::test_latex_file_revert_nested_latex_style_commands_method_challenging_ones[\\textbf{This is a \\textbf{nested} bold \\textbf{text}.}-\\textbf{This is a \\textnormal{nested} bold \\textnormal{text}.}] - The current implementation of revert_nested_latex_style_commands method does not handle the challenging cases in the test cases below.
XFAIL tests/test_renderer.py::test_latex_file_revert_nested_latex_style_commands_method_challenging_ones[\\textit{This \\textit{is} a \\textbf{n\\textit{ested}} underlined \\textit{text}.}-\\textit{This \\textnormal{is} a \\textbf{n\\textnormal{ested}} underlined \\textnormal{text}.}] - The current implementation of revert_nested_latex_style_commands method does not handle the challenging cases in the test cases below.
==================================================================================================================== 380 passed, 1 skipped, 2 xfailed, 68 warnings in 75.48s (0:01:15) ====================================================================================================================
```