### PR TITLE
Added markdown_to_latex as a Jinja filter

### DIFF
--- a/rendercv/renderer/templater.py
+++ b/rendercv/renderer/templater.py
@@ -819,6 +819,7 @@ def setup_jinja2_environment() -> jinja2.Environment:
             get_an_item_with_a_specific_attribute_value
         )
         environment.filters["escape_latex_characters"] = escape_latex_characters
+        environment.filters["markdown_to_latex"] = markdown_to_latex
 
         jinja2_environment = environment
     else:


### PR DESCRIPTION
As described, it makes sense to have this as a filter because nested elements are not connected from markdown to latex when using custom themes with different keys.