### PR TITLE
moved page n style and date style to locale catalog in schema

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -84,23 +84,11 @@
             "title": "Disable Page Numbering",
             "type": "boolean"
           },
-          "page_numbering_style": {
-            "default": "NAME - Page PAGE_NUMBER of TOTAL_PAGES",
-            "description": "The style of the page numbering. The following placeholders can be used:\n- NAME: The name of the person\n- PAGE_NUMBER: The current page number\n- TOTAL_PAGES: The total number of pages\n- TODAY: Today's month and year (April 2024)\nThe default value is NAME - Page PAGE_NUMBER of TOTAL_PAGES.",
-            "title": "Page Numbering Style",
-            "type": "string"
-          },
           "disable_last_updated_date": {
             "default": false,
             "description": "If this option is set to true, then the last updated date will not be shown in the header. The default value is false.",
             "title": "Disable Last Updated Date",
             "type": "boolean"
-          },
-          "last_updated_date_style": {
-            "default": "Last updated in TODAY",
-            "description": "The style of the last updated date. The following placeholders can be used:\n- TODAY: Today's month and year (April 2024)\nThe default value is Last updated in TODAY.",
-            "title": "Last Updated Date Style",
-            "type": "string"
           },
           "header_font_size": {
             "default": "30 pt",
@@ -487,23 +475,11 @@
             "title": "Disable Page Numbering",
             "type": "boolean"
           },
-          "page_numbering_style": {
-            "default": "NAME - Page PAGE_NUMBER of TOTAL_PAGES",
-            "description": "The style of the page numbering. The following placeholders can be used:\n- NAME: The name of the person\n- PAGE_NUMBER: The current page number\n- TOTAL_PAGES: The total number of pages\n- TODAY: Today's month and year (April 2024)\nThe default value is NAME - Page PAGE_NUMBER of TOTAL_PAGES.",
-            "title": "Page Numbering Style",
-            "type": "string"
-          },
           "disable_last_updated_date": {
             "default": true,
             "description": "If this option is set to true, then the last updated date will not be shown in the header. The default value is true.",
             "title": "Disable Last Updated Date",
             "type": "boolean"
-          },
-          "last_updated_date_style": {
-            "default": "Last updated in TODAY",
-            "description": "The style of the last updated date. The following placeholders can be used:\n- TODAY: Today's month and year (April 2024)\nThe default value is Last updated in TODAY.",
-            "title": "Last Updated Date Style",
-            "type": "string"
           },
           "header_font_size": {
             "default": "25 pt",
@@ -910,6 +886,18 @@
                 "type": "string"
               }
             ]
+          },
+          "page_numbering_style": {
+            "default": "NAME - Page PAGE_NUMBER of TOTAL_PAGES",
+            "description": "The style of the page numbering. The following placeholders can be used:\n- NAME: The name of the person\n- PAGE_NUMBER: The current page number\n- TOTAL_PAGES: The total number of pages\n- TODAY: Today's month and year (April 2024)\nThe default value is NAME - Page PAGE_NUMBER of TOTAL_PAGES.",
+            "title": "Page Numbering Style",
+            "type": "string"
+          },
+          "last_updated_date_style": {
+            "default": "Last updated in TODAY",
+            "description": "The style of the last updated date. The following placeholders can be used:\n- TODAY: Today's month and year (April 2024)\nThe default value is Last updated in TODAY.",
+            "title": "Last Updated Date Style",
+            "type": "string"
           },
           "date_style": {
             "default": "MONTH_ABBREVIATION YEAR",
@@ -1794,23 +1782,11 @@
             "title": "Disable Page Numbering",
             "type": "boolean"
           },
-          "page_numbering_style": {
-            "default": "NAME - Page PAGE_NUMBER of TOTAL_PAGES",
-            "description": "The style of the page numbering. The following placeholders can be used:\n- NAME: The name of the person\n- PAGE_NUMBER: The current page number\n- TOTAL_PAGES: The total number of pages\n- TODAY: Today's month and year (April 2024)\nThe default value is NAME - Page PAGE_NUMBER of TOTAL_PAGES.",
-            "title": "Page Numbering Style",
-            "type": "string"
-          },
           "disable_last_updated_date": {
             "default": false,
             "description": "If this option is set to true, then the last updated date will not be shown in the header. The default value is false.",
             "title": "Disable Last Updated Date",
             "type": "boolean"
-          },
-          "last_updated_date_style": {
-            "default": "Last updated in TODAY",
-            "description": "The style of the last updated date. The following placeholders can be used:\n- TODAY: Today's month and year (April 2024)\nThe default value is Last updated in TODAY.",
-            "title": "Last Updated Date Style",
-            "type": "string"
           },
           "header_font_size": {
             "default": "24 pt",
@@ -1955,9 +1931,7 @@
           "color": "#004f90",
           "disable_external_link_icons": false,
           "disable_page_numbering": false,
-          "page_numbering_style": "NAME - Page PAGE_NUMBER of TOTAL_PAGES",
           "disable_last_updated_date": false,
-          "last_updated_date_style": "Last updated in TODAY",
           "header_font_size": "30 pt",
           "text_alignment": "justified",
           "seperator_between_connections": "",


### PR DESCRIPTION
Since `page_numbering_style` and `last_updated_date_style` are properties of the `locale_catalog`, i've moved them in the schema to mimmic the way `phone_number_format` is formatted.