### PR TITLE
fix: build new dict when bolding to avoid shared references

### DIFF
--- a/rendercv/cli/utilities.py
+++ b/rendercv/cli/utilities.py
@@ -319,23 +319,32 @@ def make_given_keywords_bold_in_a_dictionary(
     Returns:
         The dictionary with the given keywords bold.
     """
-    new_dictionary = dictionary.copy()
-    for keyword in keywords:
-        for key, value in dictionary.items():
-            if isinstance(value, str):
-                new_dictionary[key] = value.replace(keyword, f"**{keyword}**")
-            elif isinstance(value, dict):
-                new_dictionary[key] = make_given_keywords_bold_in_a_dictionary(
-                    value, keywords
-                )
-            elif isinstance(value, list):
-                for i, item in enumerate(value):
-                    if isinstance(item, str):
-                        new_dictionary[key][i] = item.replace(keyword, f"**{keyword}**")
-                    elif isinstance(item, dict):
-                        new_dictionary[key][i] = (
-                            make_given_keywords_bold_in_a_dictionary(item, keywords)
-                        )
+    new_dictionary = {}
+    for key, value in dictionary.items():
+        if isinstance(value, str):
+            # Replace keywords in strings
+            for keyword in keywords:
+                value = value.replace(keyword, f"**{keyword}**")
+            new_dictionary[key] = value
+        elif isinstance(value, dict):
+            # Recursively process nested dictionaries
+            new_dictionary[key] = make_given_keywords_bold_in_a_dictionary(value, keywords)
+        elif isinstance(value, list):
+            # Process lists recursively
+            new_list = []
+            for item in value:
+                if isinstance(item, str):
+                    for keyword in keywords:
+                        item = item.replace(keyword, f"**{keyword}**")
+                    new_list.append(item)
+                elif isinstance(item, dict):
+                    new_list.append(make_given_keywords_bold_in_a_dictionary(item, keywords))
+                else:
+                    new_list.append(item)
+            new_dictionary[key] = new_list
+        else:
+            # Directly copy non-string, non-dict, non-list items
+            new_dictionary[key] = value
     return new_dictionary
 
 

--- a/rendercv/cli/utilities.py
+++ b/rendercv/cli/utilities.py
@@ -328,7 +328,9 @@ def make_given_keywords_bold_in_a_dictionary(
             new_dictionary[key] = value
         elif isinstance(value, dict):
             # Recursively process nested dictionaries
-            new_dictionary[key] = make_given_keywords_bold_in_a_dictionary(value, keywords)
+            new_dictionary[key] = make_given_keywords_bold_in_a_dictionary(
+                value, keywords
+            )
         elif isinstance(value, list):
             # Process lists recursively
             new_list = []
@@ -338,7 +340,9 @@ def make_given_keywords_bold_in_a_dictionary(
                         item = item.replace(keyword, f"**{keyword}**")
                     new_list.append(item)
                 elif isinstance(item, dict):
-                    new_list.append(make_given_keywords_bold_in_a_dictionary(item, keywords))
+                    new_list.append(
+                        make_given_keywords_bold_in_a_dictionary(item, keywords)
+                    )
                 else:
                     new_list.append(item)
             new_dictionary[key] = new_list

--- a/rendercv/cli/utilities.py
+++ b/rendercv/cli/utilities.py
@@ -323,9 +323,10 @@ def make_given_keywords_bold_in_a_dictionary(
     for key, value in dictionary.items():
         if isinstance(value, str):
             # Replace keywords in strings
+            temp_value = value
             for keyword in keywords:
-                value = value.replace(keyword, f"**{keyword}**")
-            new_dictionary[key] = value
+                temp_value = temp_value.replace(keyword, f"**{keyword}**")
+            new_dictionary[key] = temp_value
         elif isinstance(value, dict):
             # Recursively process nested dictionaries
             new_dictionary[key] = make_given_keywords_bold_in_a_dictionary(
@@ -336,9 +337,10 @@ def make_given_keywords_bold_in_a_dictionary(
             new_list = []
             for item in value:
                 if isinstance(item, str):
+                    temp_item = item
                     for keyword in keywords:
-                        item = item.replace(keyword, f"**{keyword}**")
-                    new_list.append(item)
+                        temp_item = temp_item.replace(keyword, f"**{keyword}**")
+                    new_list.append(temp_item)
                 elif isinstance(item, dict):
                     new_list.append(
                         make_given_keywords_bold_in_a_dictionary(item, keywords)


### PR DESCRIPTION
resolves #286 by fixing an issue in `make_given_keywords_bold_in_a_dictionary` where a shallow copy (`dictionary.copy()`) could lead to shared references between old and new dicts, causing inconsistent bolding when more than one keyword is specified. The updated function constructs a new dictionary so that no references to old data remain.