### PR TITLE
Improve packaging version comparison

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ dependencies = [
     'pydantic==2.9.2',              # to validate and parse the input file
     'pycountry==24.6.1',            # for ISO 639-3 validation
     'pydantic-extra-types==2.10.1', # to validate some extra types
+    "packaging",                    # to validate the version number
 ]
 classifiers = [
     "Intended Audience :: Science/Research",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,6 @@ dependencies = [
     'pydantic==2.9.2',              # to validate and parse the input file
     'pycountry==24.6.1',            # for ISO 639-3 validation
     'pydantic-extra-types==2.10.1', # to validate some extra types
-    "packaging",                    # to validate the version number
 ]
 classifiers = [
     "Intended Audience :: Science/Research",
@@ -86,6 +85,7 @@ full = [
     "watchdog==6.0.0",       # to poll files for updates
     "typst==0.12.2",         # to render PDF from Typst source files
     "rendercv-fonts==0.2.0", # some font files for RenderCV
+    "packaging==24.2",       # to validate the version number
 ]
 
 [project.urls]

--- a/rendercv/cli/printer.py
+++ b/rendercv/cli/printer.py
@@ -23,7 +23,7 @@ except ImportError as e:
 
     raise ImportError(_parial_install_error_message) from e
 
-from packaging.version import Version
+import packaging.version
 from rich import print
 
 from .. import __version__, data
@@ -128,7 +128,7 @@ def warn_if_new_version_is_available() -> bool:
         True if there is a new version, and False otherwise.
     """
     latest_version = utilities.get_latest_version_number_from_pypi()
-    version = Version(__version__)
+    version = packaging.version.Version(__version__)
     if latest_version is not None and version < latest_version:
         warning(
             f"A new version of RenderCV is available! You are using v{__version__},"

--- a/rendercv/cli/printer.py
+++ b/rendercv/cli/printer.py
@@ -22,6 +22,8 @@ except ImportError as e:
     from .. import _parial_install_error_message
 
     raise ImportError(_parial_install_error_message) from e
+
+from packaging.version import Version
 from rich import print
 
 from .. import __version__, data
@@ -126,7 +128,8 @@ def warn_if_new_version_is_available() -> bool:
         True if there is a new version, and False otherwise.
     """
     latest_version = utilities.get_latest_version_number_from_pypi()
-    if latest_version is not None and __version__ != latest_version:
+    version = Version(__version__)
+    if latest_version is not None and version < latest_version:
         warning(
             f"A new version of RenderCV is available! You are using v{__version__},"
             f" and the latest version is v{latest_version}."

--- a/rendercv/cli/utilities.py
+++ b/rendercv/cli/utilities.py
@@ -20,6 +20,8 @@ except ImportError as e:
 
     raise ImportError(_parial_install_error_message) from e
 
+from packaging.version import Version
+
 from .. import data, renderer
 from . import printer
 
@@ -122,7 +124,7 @@ def copy_files(paths: list[pathlib.Path] | pathlib.Path, new_path: pathlib.Path)
             shutil.copy2(file_path, png_path_with_page_number)
 
 
-def get_latest_version_number_from_pypi() -> Optional[str]:
+def get_latest_version_number_from_pypi() -> Optional[Version]:
     """Get the latest version number of RenderCV from PyPI.
 
     Example:
@@ -143,7 +145,8 @@ def get_latest_version_number_from_pypi() -> Optional[str]:
             data = response.read()
             encoding = response.info().get_content_charset("utf-8")
             json_data = json.loads(data.decode(encoding))
-            version = json_data["info"]["version"]
+            version_string = json_data["info"]["version"]
+            version = Version(version_string)
     except Exception:
         pass
 

--- a/rendercv/cli/utilities.py
+++ b/rendercv/cli/utilities.py
@@ -20,7 +20,7 @@ except ImportError as e:
 
     raise ImportError(_parial_install_error_message) from e
 
-from packaging.version import Version
+import packaging.version
 
 from .. import data, renderer
 from . import printer
@@ -124,7 +124,7 @@ def copy_files(paths: list[pathlib.Path] | pathlib.Path, new_path: pathlib.Path)
             shutil.copy2(file_path, png_path_with_page_number)
 
 
-def get_latest_version_number_from_pypi() -> Optional[Version]:
+def get_latest_version_number_from_pypi() -> Optional[packaging.version.Version]:
     """Get the latest version number of RenderCV from PyPI.
 
     Example:
@@ -146,7 +146,7 @@ def get_latest_version_number_from_pypi() -> Optional[Version]:
             encoding = response.info().get_content_charset("utf-8")
             json_data = json.loads(data.decode(encoding))
             version_string = json_data["info"]["version"]
-            version = Version(version_string)
+            version = packaging.version.Version(version_string)
     except Exception:
         pass
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -716,6 +716,7 @@ def test_rendercv_version_when_there_is_not_a_new_version(monkeypatch):
 
     result = runner.invoke(cli.app, ["--version"])
 
+    assert "A new version of RenderCV is available!" not in result.stdout
     assert __version__ in result.stdout
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,6 +12,7 @@ import pydantic
 import pytest
 import ruamel.yaml
 import typer.testing
+from packaging.version import Version
 
 import rendercv.cli as cli
 import rendercv.cli.printer as printer
@@ -670,12 +671,12 @@ def test_main_file():
 
 def test_get_latest_version_number_from_pypi():
     version = utilities.get_latest_version_number_from_pypi()
-    assert isinstance(version, str)
+    assert isinstance(version, Version)
 
 
 def test_if_welcome_prints_new_version_available(monkeypatch):
     monkeypatch.setattr(
-        utilities, "get_latest_version_number_from_pypi", lambda: "99999"
+        utilities, "get_latest_version_number_from_pypi", lambda: Version("99.99.99")
     )
     import contextlib
     import io
@@ -689,7 +690,7 @@ def test_if_welcome_prints_new_version_available(monkeypatch):
 
 def test_rendercv_version_when_there_is_a_new_version(monkeypatch):
     monkeypatch.setattr(
-        utilities, "get_latest_version_number_from_pypi", lambda: "99999"
+        utilities, "get_latest_version_number_from_pypi", lambda: Version("99.99.99")
     )
 
     result = runner.invoke(cli.app, ["--version"])
@@ -699,7 +700,7 @@ def test_rendercv_version_when_there_is_a_new_version(monkeypatch):
 
 def test_rendercv_version_when_there_is_not_a_new_version(monkeypatch):
     monkeypatch.setattr(
-        utilities, "get_latest_version_number_from_pypi", lambda: __version__
+        utilities, "get_latest_version_number_from_pypi", lambda: Version(__version__)
     )
 
     result = runner.invoke(cli.app, ["--version"])
@@ -709,12 +710,14 @@ def test_rendercv_version_when_there_is_not_a_new_version(monkeypatch):
 
 def test_warn_if_new_version_is_available(monkeypatch):
     monkeypatch.setattr(
-        utilities, "get_latest_version_number_from_pypi", lambda: __version__
+        utilities, "get_latest_version_number_from_pypi", lambda: Version(__version__)
     )
 
     assert not printer.warn_if_new_version_is_available()
 
-    monkeypatch.setattr(utilities, "get_latest_version_number_from_pypi", lambda: "999")
+    monkeypatch.setattr(
+        utilities, "get_latest_version_number_from_pypi", lambda: Version("99.99.99")
+    )
 
     assert printer.warn_if_new_version_is_available()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -698,6 +698,17 @@ def test_rendercv_version_when_there_is_a_new_version(monkeypatch):
     assert "A new version of RenderCV is available!" in result.stdout
 
 
+def test_rendercv_no_version_when_there_is_no_new_version(monkeypatch):
+    monkeypatch.setattr(
+        utilities, "get_latest_version_number_from_pypi", lambda: Version("00.00.00")
+    )
+
+    result = runner.invoke(cli.app, ["--version"])
+
+    assert "A new version of RenderCV is available!" not in result.stdout
+    assert __version__ in result.stdout
+
+
 def test_rendercv_version_when_there_is_not_a_new_version(monkeypatch):
     monkeypatch.setattr(
         utilities, "get_latest_version_number_from_pypi", lambda: Version(__version__)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,11 +8,11 @@ import sys
 import time
 from datetime import date as Date
 
+import packaging.version
 import pydantic
 import pytest
 import ruamel.yaml
 import typer.testing
-from packaging.version import Version
 
 import rendercv.cli as cli
 import rendercv.cli.printer as printer
@@ -671,12 +671,14 @@ def test_main_file():
 
 def test_get_latest_version_number_from_pypi():
     version = utilities.get_latest_version_number_from_pypi()
-    assert isinstance(version, Version)
+    assert isinstance(version, packaging.version.Version)
 
 
 def test_if_welcome_prints_new_version_available(monkeypatch):
     monkeypatch.setattr(
-        utilities, "get_latest_version_number_from_pypi", lambda: Version("99.99.99")
+        utilities,
+        "get_latest_version_number_from_pypi",
+        lambda: packaging.version.Version("99.99.99"),
     )
     import contextlib
     import io
@@ -690,7 +692,9 @@ def test_if_welcome_prints_new_version_available(monkeypatch):
 
 def test_rendercv_version_when_there_is_a_new_version(monkeypatch):
     monkeypatch.setattr(
-        utilities, "get_latest_version_number_from_pypi", lambda: Version("99.99.99")
+        utilities,
+        "get_latest_version_number_from_pypi",
+        lambda: packaging.version.Version("99.99.99"),
     )
 
     result = runner.invoke(cli.app, ["--version"])
@@ -700,7 +704,9 @@ def test_rendercv_version_when_there_is_a_new_version(monkeypatch):
 
 def test_rendercv_no_version_when_there_is_no_new_version(monkeypatch):
     monkeypatch.setattr(
-        utilities, "get_latest_version_number_from_pypi", lambda: Version("00.00.00")
+        utilities,
+        "get_latest_version_number_from_pypi",
+        lambda: packaging.version.Version("00.00.00"),
     )
 
     result = runner.invoke(cli.app, ["--version"])
@@ -711,7 +717,9 @@ def test_rendercv_no_version_when_there_is_no_new_version(monkeypatch):
 
 def test_rendercv_version_when_there_is_not_a_new_version(monkeypatch):
     monkeypatch.setattr(
-        utilities, "get_latest_version_number_from_pypi", lambda: Version(__version__)
+        utilities,
+        "get_latest_version_number_from_pypi",
+        lambda: packaging.version.Version(__version__),
     )
 
     result = runner.invoke(cli.app, ["--version"])
@@ -722,13 +730,17 @@ def test_rendercv_version_when_there_is_not_a_new_version(monkeypatch):
 
 def test_warn_if_new_version_is_available(monkeypatch):
     monkeypatch.setattr(
-        utilities, "get_latest_version_number_from_pypi", lambda: Version(__version__)
+        utilities,
+        "get_latest_version_number_from_pypi",
+        lambda: packaging.version.Version(__version__),
     )
 
     assert not printer.warn_if_new_version_is_available()
 
     monkeypatch.setattr(
-        utilities, "get_latest_version_number_from_pypi", lambda: Version("99.99.99")
+        utilities,
+        "get_latest_version_number_from_pypi",
+        lambda: packaging.version.Version("99.99.99"),
     )
 
     assert printer.warn_if_new_version_is_available()


### PR DESCRIPTION
Fixes #298.

Also uses the official [packaging](https://packaging.pypa.io/en/stable/) package to compare versions form pypi, which allows properly comparing [PEP 440](https://peps.python.org/pep-0440/) versions, like the dev version.

