### PR TITLE
Changed reader.py error message to print input type

### DIFF
--- a/rendercv/data/reader.py
+++ b/rendercv/data/reader.py
@@ -204,7 +204,7 @@ def parse_validation_errors(
         new_error = {
             "loc": tuple(location.split(".")),
             "msg": message,
-            "input": str(input),
+            "input": repr(input),
         }
 
         # if new_error is not in new_errors, then add it to new_errors


### PR DESCRIPTION
#272 states that external YAML breaks with spaces in path. In fact, even without spaces it breaks. The error message is not clear about the reason, this change helps identifying that the problem is not the spaces, but that it is a `Path` instead of a `str`.

Before:
```
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Location                                ┃ Input Value                                    ┃ Error Message                  ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ rendercv_settings.render_command.design │ /home/gca/repos/rendercv/my_design/design.yaml │ This field should be a string! │
└─────────────────────────────────────────┴────────────────────────────────────────────────┴────────────────────────────────┘
```

After:
```
There are some errors in the data model!                                                                                                  
                                                                                                                                          
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Location                                ┃ Input Value                                                 ┃ Error Message                  ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ rendercv_settings.render_command.design │ PosixPath('/home/gca/repos/rendercv/my_design/design.yaml') │ This field should be a string! │
└─────────────────────────────────────────┴─────────────────────────────────────────────────────────────┴────────────────────────────────┘
```