### PR TITLE
Pass data model to templates in renderer

### DIFF
--- a/rendercv/cli/utilities.py
+++ b/rendercv/cli/utilities.py
@@ -405,7 +405,8 @@ def run_rendercv_with_printer(
                 )
 
                 html_file_path_in_output_folder = renderer.render_an_html_from_markdown(
-                    markdown_file_path_in_output_folder
+                    markdown_file_path_in_output_folder,
+                    data_model
                 )
                 if render_command_settings.html_path:
                     copy_files(

--- a/rendercv/renderer/renderer.py
+++ b/rendercv/renderer/renderer.py
@@ -318,7 +318,7 @@ def render_pngs_from_typst(
     return sorted(png_files, key=lambda x: int(x.stem.split("_")[-1]))
 
 
-def render_an_html_from_markdown(markdown_file_path: pathlib.Path) -> pathlib.Path:
+def render_an_html_from_markdown(markdown_file_path: pathlib.Path, rendercv_data_model: data.RenderCVDataModel) -> pathlib.Path:
     """Render an HTML file from a Markdown file with the same name and in the same
     directory. It uses `rendercv/themes/main.j2.html` as the Jinja2 template.
 
@@ -344,13 +344,9 @@ def render_an_html_from_markdown(markdown_file_path: pathlib.Path) -> pathlib.Pa
     markdown_text = markdown_file_path.read_text(encoding="utf-8")
     html_body = markdown.markdown(markdown_text)
 
-    # Get the title of the markdown content:
-    title = re.search(r"# (.*)\n", markdown_text)
-    title = title.group(1) if title else None
-
     jinja2_environment = templater.Jinja2Environment().environment
     html_template = jinja2_environment.get_template("main.j2.html")
-    html = html_template.render(html_body=html_body, title=title)
+    html = html_template.render(html_body=html_body, cv=rendercv_data_model.cv)
 
     # Write html into a file:
     html_file_path = markdown_file_path.parent / f"{markdown_file_path.stem}.html"


### PR DESCRIPTION
Hi! 
I made this adjustment because it enables the user to read any value from the data model in the renderer. As far as I could tell, that was not possible before. Hence, here is the pull request. As always, if I missed something, feel free to reject or let me know.

I tried adjusting the tests, but no matter how much i change the functions _directly relating to the modified `render_an_html_from_markdown`_, for the life of me I cannot figure out why line 37 of reader.py causes errors. I think it may not be related to the function itself, but rather a preexisting condition exposed by the function after the change. 

```python
    for entries in sections_input.values():
        for i, entry in enumerate(entries):
            if isinstance(entry, str):
                entries[i] = entry_types.make_keywords_bold_in_a_string(entry, keywords)
            elif callable(getattr(entry, "make_keywords_bold", None)):
                entries[i] = entry.make_keywords_bold(keywords)  # type: ignore
```

The tests that fail are:

```log
============================== short test summary info ==============================
SKIPPED [1] tests/test_data.py:138: This test doesn't work currently, due to the `rendercv_settings.date` field.
SKIPPED [8] tests/test_hatch_scripts.py:10: They fail on GitHub Actions
SKIPPED [1] tests/test_hatch_scripts.py:30: They fail on GitHub Actions
FAILED tests/test_renderer.py::test_render_an_html_from_markdown[rendercv_empty_curriculum_vitae_data_model-classic] - AssertionError: assert False
FAILED tests/test_renderer.py::test_render_an_html_from_markdown[rendercv_empty_curriculum_vitae_data_model-sb2nov] - AssertionError: assert False
FAILED tests/test_renderer.py::test_render_an_html_from_markdown[rendercv_empty_curriculum_vitae_data_model-engineeringresumes] - AssertionError: assert False
FAILED tests/test_renderer.py::test_render_an_html_from_markdown[rendercv_empty_curriculum_vitae_data_model-engineeringclassic] - AssertionError: assert False
FAILED tests/test_renderer.py::test_render_an_html_from_markdown[rendercv_empty_curriculum_vitae_data_model-moderncv] - AssertionError: assert False
FAILED tests/test_renderer.py::test_render_an_html_from_markdown[rendercv_filled_curriculum_vitae_data_model-classic] - AssertionError: assert False
FAILED tests/test_renderer.py::test_render_an_html_from_markdown[rendercv_filled_curriculum_vitae_data_model-sb2nov] - AssertionError: assert False
FAILED tests/test_renderer.py::test_render_an_html_from_markdown[rendercv_filled_curriculum_vitae_data_model-engineeringresumes] - AssertionError: assert False
FAILED tests/test_renderer.py::test_render_an_html_from_markdown[rendercv_filled_curriculum_vitae_data_model-engineeringclassic] - AssertionError: assert False
FAILED tests/test_renderer.py::test_render_an_html_from_markdown[rendercv_filled_curriculum_vitae_data_model-moderncv] - AssertionError: assert False
============= 10 failed, 412 passed, 10 skipped, 62 warnings in 56.80s ==============
```