### PR TITLE
Add 'nationality' and 'birthdate' keys

### DIFF
--- a/docs/user_guide/structure_of_the_yaml_input_file.md
+++ b/docs/user_guide/structure_of_the_yaml_input_file.md
@@ -53,6 +53,8 @@ The `cv` field of the YAML input starts with generic information, as shown below
 cv:
   name: John Doe
   location: Your Location
+  nationality: American
+  birthdate: 1990-01-31
   email: youremail@yourdomain.com
   phone: +905419999999 # (1)!
   website: https://example.com/
@@ -75,6 +77,8 @@ The main content of your CV is stored in a field called `sections`.
 cv:
   name: John Doe
   location: Your Location
+  nationality: American
+  birthdate: 1990-01-31
   email: youremail@yourdomain.com
   phone: +905419999999
   website: https://yourwebsite.com/

--- a/rendercv/data/models/curriculum_vitae.py
+++ b/rendercv/data/models/curriculum_vitae.py
@@ -7,6 +7,7 @@ import functools
 import pathlib
 import re
 from typing import Annotated, Any, Literal, Optional, get_args
+import datetime
 
 import pydantic
 import pydantic_extra_types.phone_numbers as pydantic_phone_numbers
@@ -407,6 +408,18 @@ class CurriculumVitae(RenderCVBaseModelWithExtraKeys):
         default=None,
         title="Location",
     )
+    nationality: Optional[str] = pydantic.Field(
+        default=None,
+        title="Nationality",
+    )
+    birthdate: Optional[datetime.date] = pydantic.Field(
+        default=None,
+        title="Birthdate",
+        description=(
+            "The birthdate of the person. It should be in the format YYYY-MM-DD, for"
+            " example, 1990-01-01."
+        ),
+    )
     email: Optional[pydantic.EmailStr] = pydantic.Field(
         default=None,
         title="Email",
@@ -476,6 +489,26 @@ class CurriculumVitae(RenderCVBaseModelWithExtraKeys):
         """
 
         connections: list[dict[str, Optional[str]]] = []
+
+        if self.nationality is not None:
+            connections.append(
+                {
+                    "typst_icon": "passport",
+                    "url": None,
+                    "clean_url": None,
+                    "placeholder": self.nationality,
+                }
+            )
+
+        if self.birthdate is not None:
+            connections.append(
+                {
+                    "typst_icon": "cake-candles",
+                    "url": None,
+                    "clean_url": None,
+                    "placeholder": self.birthdate.strftime("%Y-%m-%d"),
+                }
+            )
 
         if self.location is not None:
             connections.append(

--- a/rendercv/data/sample_content.yaml
+++ b/rendercv/data/sample_content.yaml
@@ -1,6 +1,8 @@
 ---
 name: John Doe
 location: Location
+nationality: American
+birthdate: 1990-01-31
 email: john.doe@example.com
 phone: +1-609-999-9995
 social_networks:

--- a/schema.json
+++ b/schema.json
@@ -174,6 +174,31 @@
             }
           ]
         },
+        "nationality": {
+          "default": null,
+          "title": "Nationality",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "birthdate": {
+          "default": null,
+          "title": "Birthdate",
+          "oneOf": [
+            {
+              "type": "string",
+              "format": "date"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "location": {
           "default": null,
           "title": "Location",


### PR DESCRIPTION
Awesome project! 
I wanted to contribute adding `cv.nationality` and `cv.birthdate` to connections, as discussed in #383  and #407.
Note that the unit tests currently fail, but this seems to be an upstream issue  (e.g. [here](https://github.com/rendercv/rendercv/actions/runs/15381140834/job/43272092002#step:4:648)).

Any additional modifications to the PR are of course welcome