### PR TITLE
Bump typer version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ dynamic = ["version"] # We will use hatchling to generate the version number
 
 [project.optional-dependencies]
 full = [
-    'typer==0.15.2',   # to create the command-line interface
+    'typer==0.16.0',   # to create the command-line interface
     "markdown==3.7",   # to convert Markdown to HTML
     "watchdog==6.0.0", # to poll files for updates
     "typst==0.13.1",   # to render PDF from Typst source files


### PR DESCRIPTION
Fix #440. Another person encountered the same issue at https://github.com/lmstudio-ai/venvstacks/issues/171, which is fixed in https://github.com/fastapi/typer/pull/1222. The change is rolled out in a later version, but I think it is best to bump to the latest version.