### PR TITLE
Arbitrary keys bug?

### DIFF
--- a/rendercv/renderer/templater.py
+++ b/rendercv/renderer/templater.py
@@ -745,11 +745,13 @@ def replace_placeholders_with_actual_values(
         The string with actual values.
     """
     for placeholder, value in placeholders.items():
-        if value:
-            text = text.replace(placeholder, str(value))
+        # Use regex only for whole-word placeholders like DATE, NAME, etc.
+        if re.fullmatch(r"\w+", placeholder):  # e.g., "DATE", "NAME"
+            pattern = rf"\b{placeholder}\b"
+            text = re.sub(pattern, str(value or ""), text)
         else:
-            text = text.replace(placeholder, "")
-
+            # Fall back to literal replacement if placeholder is not a word (e.g., "{name}")
+            text = text.replace(placeholder, str(value or ""))
     return text
 
 

--- a/rendercv/renderer/templater.py
+++ b/rendercv/renderer/templater.py
@@ -191,7 +191,8 @@ class TypstFile(TemplatedFile):
                             section_title=section.title,
                         )
                     else:
-                        placeholder_value = getattr(entry, placeholder_key, None)
+                        arbitrary_keys = getattr(entry, "model_extra", None)
+                        placeholder_value = arbitrary_keys.get(lowercase_placeholder_key, None) if isinstance(arbitrary_keys, dict) else None
 
                     placeholders[placeholder_key] = (
                         placeholder_value if placeholder_value != "None" else None


### PR DESCRIPTION
It seems that this line in templater.py originally would always return None. Since arbitrary keys in the yaml was not working properly, I assume it is meant to return the artbitrary keys. If so, I fixed it, so that it would return arbitrary keys.