### PR TITLE
build: Enable parallel test execution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,7 @@ dependencies = [
     "pyright",             # to check the types
     "pre-commit",          # to run the checks before committing
     "pytest==8.3.4",       # to run the tests
+    "pytest-xdist>=3.8.0", # to run tests in parallel
     "coverage==7.6.10",    # to generate coverage reports
     "pypdf==5.1.0",        # to read PDF files
     "snakeviz==2.2.2",     # for profiling
@@ -279,5 +280,7 @@ addopts = [
     "-v",               # Increase verbosity
     "--strict-markers", # Don't allow unknown markers
     "--strict-config",  # Always fail if there are unknown configuration options
+    "--numprocesses",
+    "auto",
 ]
 testpaths = ["tests"]


### PR DESCRIPTION
using [pytest-xdist](https://github.com/pytest-dev/pytest-xdist) to run the `pytests` in parallel, can drastically speed up test time. In my experience this is usually around an order of $log(n_{cores})$ faster due to overhead from pytest, i/o, and other factors

I ran this on a 4 core (8 thread) laptop, with 1 round for warmup of any pycache and got these results

**Stats for sequential tests**
```bash
❯ hyperfine -i -w 1 pytest
Benchmark 1: auto
  Time (mean ± σ):     78.830 s ±  0.977 s    [User: 65.533 s, System: 2.107 s]
  Range (min … max):   77.730 s … 80.920 s    10 runs
```


**Stats for parallel tests**
```bash
❯ hyperfine -i -w 1 'pytest -n auto'
Benchmark 1: pytest -n auto
  Time (mean ± σ):     28.237 s ±  0.784 s    [User: 146.731 s, System: 6.666 s]
  Range (min … max):   27.069 s … 29.815 s    10 runs
```

so the test time got more than halved just by adding `pytest-xdist` and running `pytest -n auto` as compared to `pytest`