### PR TITLE
Fix #547: Add TIME_SPAN placeholder for custom entry templates

### DIFF
--- a/docs/user_guide/yaml_input_structure/design.md
+++ b/docs/user_guide/yaml_input_structure/design.md
@@ -186,5 +186,5 @@ design:
    `national` formats for domestic use, `international` includes country code, `E164` is the standard international format
 8. **Photo position:** `left` or `right` of the header text
 9. **Available fonts:** << available_font_families >>. Also, any system font can be used. Custom fonts can be used as well. See [Custom Fonts](../how_to/custom_fonts.md) for more information.
-10. **Templates:** Advanced customization - define how each entry type is rendered using placeholders like NAME, COMPANY, DATE, etc.
+10. **Templates:** Advanced customization - define how each entry type is rendered using placeholders like NAME, COMPANY, DATE, START_DATE, END_DATE, and TIME_SPAN. For ranged entries, `DATE` still includes the time span when enabled; use `START_DATE`, `END_DATE`, and `TIME_SPAN` if you want to place them separately.
 11. **Font family shorthand:** You can specify `font_family: "Latin Modern Roman"` directly instead of using nested options to apply the same font everywhere

--- a/schema.json
+++ b/schema.json
@@ -4712,7 +4712,7 @@
       "properties": {
         "main_column": {
           "default": "**INSTITUTION**, AREA\nSUMMARY\nHIGHLIGHTS",
-          "description": "Template for education entry main column. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `DEGREE_WITH_AREA`: Locale-aware phrase combining degree and area (e.g., 'BS in Computer Science')\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**INSTITUTION**, AREA\\nSUMMARY\\nHIGHLIGHTS`.",
+          "description": "Template for education entry main column. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `DEGREE_WITH_AREA`: Locale-aware phrase combining degree and area (e.g., 'BS in Computer Science')\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**INSTITUTION**, AREA\\nSUMMARY\\nHIGHLIGHTS`.",
           "title": "Main Column",
           "type": "string"
         },
@@ -4726,12 +4726,12 @@
             }
           ],
           "default": "**DEGREE**",
-          "description": "Optional degree column template. If provided, displays degree in separate column. If `null`, no degree column is shown. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**DEGREE**`.",
+          "description": "Optional degree column template. If provided, displays degree in separate column. If `null`, no degree column is shown. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**DEGREE**`.",
           "title": "Degree Column"
         },
         "date_and_location_column": {
           "default": "LOCATION\nDATE",
-          "description": "Template for education entry date/location column. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
+          "description": "Template for education entry date/location column. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
           "title": "Date And Location Column",
           "type": "string"
         }
@@ -4744,7 +4744,7 @@
       "properties": {
         "main_column": {
           "default": "**INSTITUTION** -- LOCATION\n*DEGREE_WITH_AREA*\nSUMMARY\nHIGHLIGHTS",
-          "description": "Template for education entry main column. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `DEGREE_WITH_AREA`: Locale-aware phrase combining degree and area (e.g., 'BS in Computer Science')\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**INSTITUTION**, AREA\\nSUMMARY\\nHIGHLIGHTS`.",
+          "description": "Template for education entry main column. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `DEGREE_WITH_AREA`: Locale-aware phrase combining degree and area (e.g., 'BS in Computer Science')\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**INSTITUTION**, AREA\\nSUMMARY\\nHIGHLIGHTS`.",
           "title": "Main Column",
           "type": "string"
         },
@@ -4758,12 +4758,12 @@
             }
           ],
           "default": null,
-          "description": "Optional degree column template. If provided, displays degree in separate column. If `null`, no degree column is shown. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `None`.",
+          "description": "Optional degree column template. If provided, displays degree in separate column. If `null`, no degree column is shown. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `None`.",
           "title": "Degree Column"
         },
         "date_and_location_column": {
           "default": "DATE",
-          "description": "Template for education entry date/location column. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
+          "description": "Template for education entry date/location column. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
           "title": "Date And Location Column",
           "type": "string"
         }
@@ -4776,7 +4776,7 @@
       "properties": {
         "main_column": {
           "default": "**INSTITUTION**, DEGREE_WITH_AREA -- LOCATION\nSUMMARY\nHIGHLIGHTS",
-          "description": "Template for education entry main column. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `DEGREE_WITH_AREA`: Locale-aware phrase combining degree and area (e.g., 'BS in Computer Science')\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**INSTITUTION**, AREA\\nSUMMARY\\nHIGHLIGHTS`.",
+          "description": "Template for education entry main column. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `DEGREE_WITH_AREA`: Locale-aware phrase combining degree and area (e.g., 'BS in Computer Science')\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**INSTITUTION**, AREA\\nSUMMARY\\nHIGHLIGHTS`.",
           "title": "Main Column",
           "type": "string"
         },
@@ -4790,12 +4790,12 @@
             }
           ],
           "default": null,
-          "description": "Optional degree column template. If provided, displays degree in separate column. If `null`, no degree column is shown. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `None`.",
+          "description": "Optional degree column template. If provided, displays degree in separate column. If `null`, no degree column is shown. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `None`.",
           "title": "Degree Column"
         },
         "date_and_location_column": {
           "default": "DATE",
-          "description": "Template for education entry date/location column. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
+          "description": "Template for education entry date/location column. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
           "title": "Date And Location Column",
           "type": "string"
         }
@@ -4808,7 +4808,7 @@
       "properties": {
         "main_column": {
           "default": "**INSTITUTION**, DEGREE_WITH_AREA -- LOCATION\nSUMMARY\nHIGHLIGHTS",
-          "description": "Template for education entry main column. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `DEGREE_WITH_AREA`: Locale-aware phrase combining degree and area (e.g., 'BS in Computer Science')\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**INSTITUTION**, AREA\\nSUMMARY\\nHIGHLIGHTS`.",
+          "description": "Template for education entry main column. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `DEGREE_WITH_AREA`: Locale-aware phrase combining degree and area (e.g., 'BS in Computer Science')\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**INSTITUTION**, AREA\\nSUMMARY\\nHIGHLIGHTS`.",
           "title": "Main Column",
           "type": "string"
         },
@@ -4822,12 +4822,12 @@
             }
           ],
           "default": null,
-          "description": "Optional degree column template. If provided, displays degree in separate column. If `null`, no degree column is shown. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `None`.",
+          "description": "Optional degree column template. If provided, displays degree in separate column. If `null`, no degree column is shown. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `None`.",
           "title": "Degree Column"
         },
         "date_and_location_column": {
           "default": "DATE",
-          "description": "Template for education entry date/location column. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
+          "description": "Template for education entry date/location column. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
           "title": "Date And Location Column",
           "type": "string"
         }
@@ -4840,7 +4840,7 @@
       "properties": {
         "main_column": {
           "default": "**INSTITUTION**, DEGREE_WITH_AREA -- LOCATION\nSUMMARY\nHIGHLIGHTS",
-          "description": "Template for education entry main column. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `DEGREE_WITH_AREA`: Locale-aware phrase combining degree and area (e.g., 'BS in Computer Science')\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**INSTITUTION**, AREA\\nSUMMARY\\nHIGHLIGHTS`.",
+          "description": "Template for education entry main column. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `DEGREE_WITH_AREA`: Locale-aware phrase combining degree and area (e.g., 'BS in Computer Science')\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**INSTITUTION**, AREA\\nSUMMARY\\nHIGHLIGHTS`.",
           "title": "Main Column",
           "type": "string"
         },
@@ -4854,12 +4854,12 @@
             }
           ],
           "default": "**DEGREE**",
-          "description": "Optional degree column template. If provided, displays degree in separate column. If `null`, no degree column is shown. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**DEGREE**`.",
+          "description": "Optional degree column template. If provided, displays degree in separate column. If `null`, no degree column is shown. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**DEGREE**`.",
           "title": "Degree Column"
         },
         "date_and_location_column": {
           "default": "DATE",
-          "description": "Template for education entry date/location column. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
+          "description": "Template for education entry date/location column. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
           "title": "Date And Location Column",
           "type": "string"
         }
@@ -4872,7 +4872,7 @@
       "properties": {
         "main_column": {
           "default": "**INSTITUTION** -- LOCATION\n*DEGREE_WITH_AREA*\nSUMMARY\nHIGHLIGHTS",
-          "description": "Template for education entry main column. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `DEGREE_WITH_AREA`: Locale-aware phrase combining degree and area (e.g., 'BS in Computer Science')\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**INSTITUTION**, AREA\\nSUMMARY\\nHIGHLIGHTS`.",
+          "description": "Template for education entry main column. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `DEGREE_WITH_AREA`: Locale-aware phrase combining degree and area (e.g., 'BS in Computer Science')\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**INSTITUTION**, AREA\\nSUMMARY\\nHIGHLIGHTS`.",
           "title": "Main Column",
           "type": "string"
         },
@@ -4886,12 +4886,12 @@
             }
           ],
           "default": null,
-          "description": "Optional degree column template. If provided, displays degree in separate column. If `null`, no degree column is shown. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `None`.",
+          "description": "Optional degree column template. If provided, displays degree in separate column. If `null`, no degree column is shown. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `None`.",
           "title": "Degree Column"
         },
         "date_and_location_column": {
           "default": "DATE",
-          "description": "Template for education entry date/location column. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
+          "description": "Template for education entry date/location column. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
           "title": "Date And Location Column",
           "type": "string"
         }
@@ -4904,7 +4904,7 @@
       "properties": {
         "main_column": {
           "default": "**INSTITUTION**, DEGREE_WITH_AREA -- LOCATION\nSUMMARY\nHIGHLIGHTS",
-          "description": "Template for education entry main column. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `DEGREE_WITH_AREA`: Locale-aware phrase combining degree and area (e.g., 'BS in Computer Science')\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**INSTITUTION**, AREA\\nSUMMARY\\nHIGHLIGHTS`.",
+          "description": "Template for education entry main column. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `DEGREE_WITH_AREA`: Locale-aware phrase combining degree and area (e.g., 'BS in Computer Science')\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**INSTITUTION**, AREA\\nSUMMARY\\nHIGHLIGHTS`.",
           "title": "Main Column",
           "type": "string"
         },
@@ -4918,12 +4918,12 @@
             }
           ],
           "default": null,
-          "description": "Optional degree column template. If provided, displays degree in separate column. If `null`, no degree column is shown. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `None`.",
+          "description": "Optional degree column template. If provided, displays degree in separate column. If `null`, no degree column is shown. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `None`.",
           "title": "Degree Column"
         },
         "date_and_location_column": {
           "default": "DATE",
-          "description": "Template for education entry date/location column. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
+          "description": "Template for education entry date/location column. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
           "title": "Date And Location Column",
           "type": "string"
         }
@@ -4936,7 +4936,7 @@
       "properties": {
         "main_column": {
           "default": "**INSTITUTION** -- LOCATION\nDEGREE_WITH_AREA\nSUMMARY\nHIGHLIGHTS",
-          "description": "Template for education entry main column. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `DEGREE_WITH_AREA`: Locale-aware phrase combining degree and area (e.g., 'BS in Computer Science')\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**INSTITUTION**, AREA\\nSUMMARY\\nHIGHLIGHTS`.",
+          "description": "Template for education entry main column. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `DEGREE_WITH_AREA`: Locale-aware phrase combining degree and area (e.g., 'BS in Computer Science')\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**INSTITUTION**, AREA\\nSUMMARY\\nHIGHLIGHTS`.",
           "title": "Main Column",
           "type": "string"
         },
@@ -4950,12 +4950,12 @@
             }
           ],
           "default": null,
-          "description": "Optional degree column template. If provided, displays degree in separate column. If `null`, no degree column is shown. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `None`.",
+          "description": "Optional degree column template. If provided, displays degree in separate column. If `null`, no degree column is shown. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `None`.",
           "title": "Degree Column"
         },
         "date_and_location_column": {
           "default": "DATE",
-          "description": "Template for education entry date/location column. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
+          "description": "Template for education entry date/location column. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
           "title": "Date And Location Column",
           "type": "string"
         }
@@ -4968,7 +4968,7 @@
       "properties": {
         "main_column": {
           "default": "**INSTITUTION**\n*DEGREE* *in* *AREA*\nSUMMARY\nHIGHLIGHTS",
-          "description": "Template for education entry main column. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `DEGREE_WITH_AREA`: Locale-aware phrase combining degree and area (e.g., 'BS in Computer Science')\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**INSTITUTION**, AREA\\nSUMMARY\\nHIGHLIGHTS`.",
+          "description": "Template for education entry main column. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `DEGREE_WITH_AREA`: Locale-aware phrase combining degree and area (e.g., 'BS in Computer Science')\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**INSTITUTION**, AREA\\nSUMMARY\\nHIGHLIGHTS`.",
           "title": "Main Column",
           "type": "string"
         },
@@ -4982,12 +4982,12 @@
             }
           ],
           "default": null,
-          "description": "Optional degree column template. If provided, displays degree in separate column. If `null`, no degree column is shown. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `None`.",
+          "description": "Optional degree column template. If provided, displays degree in separate column. If `null`, no degree column is shown. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `None`.",
           "title": "Degree Column"
         },
         "date_and_location_column": {
           "default": "*LOCATION*\n*DATE*",
-          "description": "Template for education entry date/location column. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
+          "description": "Template for education entry date/location column. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
           "title": "Date And Location Column",
           "type": "string"
         }
@@ -5423,13 +5423,13 @@
       "properties": {
         "main_column": {
           "default": "**COMPANY**, POSITION\nSUMMARY\nHIGHLIGHTS",
-          "description": "Template for experience entry main column. Available placeholders:\n- `COMPANY`: Company name\n- `POSITION`: Job title/position\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**COMPANY**, POSITION\\nSUMMARY\\nHIGHLIGHTS`.",
+          "description": "Template for experience entry main column. Available placeholders:\n- `COMPANY`: Company name\n- `POSITION`: Job title/position\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**COMPANY**, POSITION\\nSUMMARY\\nHIGHLIGHTS`.",
           "title": "Main Column",
           "type": "string"
         },
         "date_and_location_column": {
           "default": "LOCATION\nDATE",
-          "description": "Template for experience entry date/location column. Available placeholders:\n- `COMPANY`: Company name\n- `POSITION`: Job title/position\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
+          "description": "Template for experience entry date/location column. Available placeholders:\n- `COMPANY`: Company name\n- `POSITION`: Job title/position\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
           "title": "Date And Location Column",
           "type": "string"
         }
@@ -5442,13 +5442,13 @@
       "properties": {
         "main_column": {
           "default": "**COMPANY** -- LOCATION\n*POSITION*\nSUMMARY\nHIGHLIGHTS",
-          "description": "Template for experience entry main column. Available placeholders:\n- `COMPANY`: Company name\n- `POSITION`: Job title/position\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**COMPANY**, POSITION\\nSUMMARY\\nHIGHLIGHTS`.",
+          "description": "Template for experience entry main column. Available placeholders:\n- `COMPANY`: Company name\n- `POSITION`: Job title/position\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**COMPANY**, POSITION\\nSUMMARY\\nHIGHLIGHTS`.",
           "title": "Main Column",
           "type": "string"
         },
         "date_and_location_column": {
           "default": "DATE",
-          "description": "Template for experience entry date/location column. Available placeholders:\n- `COMPANY`: Company name\n- `POSITION`: Job title/position\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
+          "description": "Template for experience entry date/location column. Available placeholders:\n- `COMPANY`: Company name\n- `POSITION`: Job title/position\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
           "title": "Date And Location Column",
           "type": "string"
         }
@@ -5461,13 +5461,13 @@
       "properties": {
         "main_column": {
           "default": "**POSITION**, COMPANY -- LOCATION\nSUMMARY\nHIGHLIGHTS",
-          "description": "Template for experience entry main column. Available placeholders:\n- `COMPANY`: Company name\n- `POSITION`: Job title/position\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**COMPANY**, POSITION\\nSUMMARY\\nHIGHLIGHTS`.",
+          "description": "Template for experience entry main column. Available placeholders:\n- `COMPANY`: Company name\n- `POSITION`: Job title/position\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**COMPANY**, POSITION\\nSUMMARY\\nHIGHLIGHTS`.",
           "title": "Main Column",
           "type": "string"
         },
         "date_and_location_column": {
           "default": "DATE",
-          "description": "Template for experience entry date/location column. Available placeholders:\n- `COMPANY`: Company name\n- `POSITION`: Job title/position\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
+          "description": "Template for experience entry date/location column. Available placeholders:\n- `COMPANY`: Company name\n- `POSITION`: Job title/position\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
           "title": "Date And Location Column",
           "type": "string"
         }
@@ -5480,13 +5480,13 @@
       "properties": {
         "main_column": {
           "default": "**POSITION**, COMPANY -- LOCATION\nSUMMARY\nHIGHLIGHTS",
-          "description": "Template for experience entry main column. Available placeholders:\n- `COMPANY`: Company name\n- `POSITION`: Job title/position\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**COMPANY**, POSITION\\nSUMMARY\\nHIGHLIGHTS`.",
+          "description": "Template for experience entry main column. Available placeholders:\n- `COMPANY`: Company name\n- `POSITION`: Job title/position\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**COMPANY**, POSITION\\nSUMMARY\\nHIGHLIGHTS`.",
           "title": "Main Column",
           "type": "string"
         },
         "date_and_location_column": {
           "default": "DATE",
-          "description": "Template for experience entry date/location column. Available placeholders:\n- `COMPANY`: Company name\n- `POSITION`: Job title/position\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
+          "description": "Template for experience entry date/location column. Available placeholders:\n- `COMPANY`: Company name\n- `POSITION`: Job title/position\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
           "title": "Date And Location Column",
           "type": "string"
         }
@@ -5499,13 +5499,13 @@
       "properties": {
         "main_column": {
           "default": "**COMPANY**, POSITION -- LOCATION\nSUMMARY\nHIGHLIGHTS",
-          "description": "Template for experience entry main column. Available placeholders:\n- `COMPANY`: Company name\n- `POSITION`: Job title/position\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**COMPANY**, POSITION\\nSUMMARY\\nHIGHLIGHTS`.",
+          "description": "Template for experience entry main column. Available placeholders:\n- `COMPANY`: Company name\n- `POSITION`: Job title/position\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**COMPANY**, POSITION\\nSUMMARY\\nHIGHLIGHTS`.",
           "title": "Main Column",
           "type": "string"
         },
         "date_and_location_column": {
           "default": "DATE",
-          "description": "Template for experience entry date/location column. Available placeholders:\n- `COMPANY`: Company name\n- `POSITION`: Job title/position\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
+          "description": "Template for experience entry date/location column. Available placeholders:\n- `COMPANY`: Company name\n- `POSITION`: Job title/position\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
           "title": "Date And Location Column",
           "type": "string"
         }
@@ -5518,13 +5518,13 @@
       "properties": {
         "main_column": {
           "default": "**COMPANY** -- LOCATION\n*POSITION*\nSUMMARY\nHIGHLIGHTS",
-          "description": "Template for experience entry main column. Available placeholders:\n- `COMPANY`: Company name\n- `POSITION`: Job title/position\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**COMPANY**, POSITION\\nSUMMARY\\nHIGHLIGHTS`.",
+          "description": "Template for experience entry main column. Available placeholders:\n- `COMPANY`: Company name\n- `POSITION`: Job title/position\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**COMPANY**, POSITION\\nSUMMARY\\nHIGHLIGHTS`.",
           "title": "Main Column",
           "type": "string"
         },
         "date_and_location_column": {
           "default": "DATE",
-          "description": "Template for experience entry date/location column. Available placeholders:\n- `COMPANY`: Company name\n- `POSITION`: Job title/position\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
+          "description": "Template for experience entry date/location column. Available placeholders:\n- `COMPANY`: Company name\n- `POSITION`: Job title/position\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
           "title": "Date And Location Column",
           "type": "string"
         }
@@ -5537,13 +5537,13 @@
       "properties": {
         "main_column": {
           "default": "**POSITION**, COMPANY -- LOCATION\nSUMMARY\nHIGHLIGHTS",
-          "description": "Template for experience entry main column. Available placeholders:\n- `COMPANY`: Company name\n- `POSITION`: Job title/position\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**COMPANY**, POSITION\\nSUMMARY\\nHIGHLIGHTS`.",
+          "description": "Template for experience entry main column. Available placeholders:\n- `COMPANY`: Company name\n- `POSITION`: Job title/position\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**COMPANY**, POSITION\\nSUMMARY\\nHIGHLIGHTS`.",
           "title": "Main Column",
           "type": "string"
         },
         "date_and_location_column": {
           "default": "DATE",
-          "description": "Template for experience entry date/location column. Available placeholders:\n- `COMPANY`: Company name\n- `POSITION`: Job title/position\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
+          "description": "Template for experience entry date/location column. Available placeholders:\n- `COMPANY`: Company name\n- `POSITION`: Job title/position\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
           "title": "Date And Location Column",
           "type": "string"
         }
@@ -5556,13 +5556,13 @@
       "properties": {
         "main_column": {
           "default": "**COMPANY**, *POSITION* -- LOCATION\nSUMMARY\nHIGHLIGHTS",
-          "description": "Template for experience entry main column. Available placeholders:\n- `COMPANY`: Company name\n- `POSITION`: Job title/position\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**COMPANY**, POSITION\\nSUMMARY\\nHIGHLIGHTS`.",
+          "description": "Template for experience entry main column. Available placeholders:\n- `COMPANY`: Company name\n- `POSITION`: Job title/position\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**COMPANY**, POSITION\\nSUMMARY\\nHIGHLIGHTS`.",
           "title": "Main Column",
           "type": "string"
         },
         "date_and_location_column": {
           "default": "DATE",
-          "description": "Template for experience entry date/location column. Available placeholders:\n- `COMPANY`: Company name\n- `POSITION`: Job title/position\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
+          "description": "Template for experience entry date/location column. Available placeholders:\n- `COMPANY`: Company name\n- `POSITION`: Job title/position\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
           "title": "Date And Location Column",
           "type": "string"
         }
@@ -5575,13 +5575,13 @@
       "properties": {
         "main_column": {
           "default": "**POSITION**\n*COMPANY*\nSUMMARY\nHIGHLIGHTS",
-          "description": "Template for experience entry main column. Available placeholders:\n- `COMPANY`: Company name\n- `POSITION`: Job title/position\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**COMPANY**, POSITION\\nSUMMARY\\nHIGHLIGHTS`.",
+          "description": "Template for experience entry main column. Available placeholders:\n- `COMPANY`: Company name\n- `POSITION`: Job title/position\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**COMPANY**, POSITION\\nSUMMARY\\nHIGHLIGHTS`.",
           "title": "Main Column",
           "type": "string"
         },
         "date_and_location_column": {
           "default": "*LOCATION*\n*DATE*",
-          "description": "Template for experience entry date/location column. Available placeholders:\n- `COMPANY`: Company name\n- `POSITION`: Job title/position\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
+          "description": "Template for experience entry date/location column. Available placeholders:\n- `COMPANY`: Company name\n- `POSITION`: Job title/position\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
           "title": "Date And Location Column",
           "type": "string"
         }
@@ -6802,13 +6802,13 @@
       "properties": {
         "main_column": {
           "default": "**NAME**\nSUMMARY\nHIGHLIGHTS",
-          "description": "Template for normal entry main column. Available placeholders:\n- `NAME`: Entry name/title\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**NAME**\\nSUMMARY\\nHIGHLIGHTS`.",
+          "description": "Template for normal entry main column. Available placeholders:\n- `NAME`: Entry name/title\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**NAME**\\nSUMMARY\\nHIGHLIGHTS`.",
           "title": "Main Column",
           "type": "string"
         },
         "date_and_location_column": {
           "default": "LOCATION\nDATE",
-          "description": "Template for normal entry date/location column. Available placeholders:\n- `NAME`: Entry name/title\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
+          "description": "Template for normal entry date/location column. Available placeholders:\n- `NAME`: Entry name/title\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
           "title": "Date And Location Column",
           "type": "string"
         }
@@ -6821,13 +6821,13 @@
       "properties": {
         "main_column": {
           "default": "**NAME** -- LOCATION\nSUMMARY\nHIGHLIGHTS",
-          "description": "Template for normal entry main column. Available placeholders:\n- `NAME`: Entry name/title\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**NAME**\\nSUMMARY\\nHIGHLIGHTS`.",
+          "description": "Template for normal entry main column. Available placeholders:\n- `NAME`: Entry name/title\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**NAME**\\nSUMMARY\\nHIGHLIGHTS`.",
           "title": "Main Column",
           "type": "string"
         },
         "date_and_location_column": {
           "default": "DATE",
-          "description": "Template for normal entry date/location column. Available placeholders:\n- `NAME`: Entry name/title\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
+          "description": "Template for normal entry date/location column. Available placeholders:\n- `NAME`: Entry name/title\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
           "title": "Date And Location Column",
           "type": "string"
         }
@@ -6840,13 +6840,13 @@
       "properties": {
         "main_column": {
           "default": "**NAME** -- **LOCATION**\nSUMMARY\nHIGHLIGHTS",
-          "description": "Template for normal entry main column. Available placeholders:\n- `NAME`: Entry name/title\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**NAME**\\nSUMMARY\\nHIGHLIGHTS`.",
+          "description": "Template for normal entry main column. Available placeholders:\n- `NAME`: Entry name/title\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**NAME**\\nSUMMARY\\nHIGHLIGHTS`.",
           "title": "Main Column",
           "type": "string"
         },
         "date_and_location_column": {
           "default": "DATE",
-          "description": "Template for normal entry date/location column. Available placeholders:\n- `NAME`: Entry name/title\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
+          "description": "Template for normal entry date/location column. Available placeholders:\n- `NAME`: Entry name/title\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
           "title": "Date And Location Column",
           "type": "string"
         }
@@ -6859,13 +6859,13 @@
       "properties": {
         "main_column": {
           "default": "**NAME** -- **LOCATION**\nSUMMARY\nHIGHLIGHTS",
-          "description": "Template for normal entry main column. Available placeholders:\n- `NAME`: Entry name/title\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**NAME**\\nSUMMARY\\nHIGHLIGHTS`.",
+          "description": "Template for normal entry main column. Available placeholders:\n- `NAME`: Entry name/title\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**NAME**\\nSUMMARY\\nHIGHLIGHTS`.",
           "title": "Main Column",
           "type": "string"
         },
         "date_and_location_column": {
           "default": "DATE",
-          "description": "Template for normal entry date/location column. Available placeholders:\n- `NAME`: Entry name/title\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
+          "description": "Template for normal entry date/location column. Available placeholders:\n- `NAME`: Entry name/title\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
           "title": "Date And Location Column",
           "type": "string"
         }
@@ -6878,13 +6878,13 @@
       "properties": {
         "main_column": {
           "default": "**NAME** -- **LOCATION**\nSUMMARY\nHIGHLIGHTS",
-          "description": "Template for normal entry main column. Available placeholders:\n- `NAME`: Entry name/title\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**NAME**\\nSUMMARY\\nHIGHLIGHTS`.",
+          "description": "Template for normal entry main column. Available placeholders:\n- `NAME`: Entry name/title\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**NAME**\\nSUMMARY\\nHIGHLIGHTS`.",
           "title": "Main Column",
           "type": "string"
         },
         "date_and_location_column": {
           "default": "DATE",
-          "description": "Template for normal entry date/location column. Available placeholders:\n- `NAME`: Entry name/title\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
+          "description": "Template for normal entry date/location column. Available placeholders:\n- `NAME`: Entry name/title\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
           "title": "Date And Location Column",
           "type": "string"
         }
@@ -6897,13 +6897,13 @@
       "properties": {
         "main_column": {
           "default": "**NAME** -- **LOCATION**\nSUMMARY\nHIGHLIGHTS",
-          "description": "Template for normal entry main column. Available placeholders:\n- `NAME`: Entry name/title\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**NAME**\\nSUMMARY\\nHIGHLIGHTS`.",
+          "description": "Template for normal entry main column. Available placeholders:\n- `NAME`: Entry name/title\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**NAME**\\nSUMMARY\\nHIGHLIGHTS`.",
           "title": "Main Column",
           "type": "string"
         },
         "date_and_location_column": {
           "default": "DATE",
-          "description": "Template for normal entry date/location column. Available placeholders:\n- `NAME`: Entry name/title\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
+          "description": "Template for normal entry date/location column. Available placeholders:\n- `NAME`: Entry name/title\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
           "title": "Date And Location Column",
           "type": "string"
         }
@@ -6916,13 +6916,13 @@
       "properties": {
         "main_column": {
           "default": "**NAME** -- **LOCATION**\nSUMMARY\nHIGHLIGHTS",
-          "description": "Template for normal entry main column. Available placeholders:\n- `NAME`: Entry name/title\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**NAME**\\nSUMMARY\\nHIGHLIGHTS`.",
+          "description": "Template for normal entry main column. Available placeholders:\n- `NAME`: Entry name/title\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**NAME**\\nSUMMARY\\nHIGHLIGHTS`.",
           "title": "Main Column",
           "type": "string"
         },
         "date_and_location_column": {
           "default": "DATE",
-          "description": "Template for normal entry date/location column. Available placeholders:\n- `NAME`: Entry name/title\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
+          "description": "Template for normal entry date/location column. Available placeholders:\n- `NAME`: Entry name/title\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
           "title": "Date And Location Column",
           "type": "string"
         }
@@ -6935,13 +6935,13 @@
       "properties": {
         "main_column": {
           "default": "**NAME** -- LOCATION\nSUMMARY\nHIGHLIGHTS",
-          "description": "Template for normal entry main column. Available placeholders:\n- `NAME`: Entry name/title\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**NAME**\\nSUMMARY\\nHIGHLIGHTS`.",
+          "description": "Template for normal entry main column. Available placeholders:\n- `NAME`: Entry name/title\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**NAME**\\nSUMMARY\\nHIGHLIGHTS`.",
           "title": "Main Column",
           "type": "string"
         },
         "date_and_location_column": {
           "default": "DATE",
-          "description": "Template for normal entry date/location column. Available placeholders:\n- `NAME`: Entry name/title\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
+          "description": "Template for normal entry date/location column. Available placeholders:\n- `NAME`: Entry name/title\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
           "title": "Date And Location Column",
           "type": "string"
         }
@@ -6954,13 +6954,13 @@
       "properties": {
         "main_column": {
           "default": "**NAME**\nSUMMARY\nHIGHLIGHTS",
-          "description": "Template for normal entry main column. Available placeholders:\n- `NAME`: Entry name/title\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**NAME**\\nSUMMARY\\nHIGHLIGHTS`.",
+          "description": "Template for normal entry main column. Available placeholders:\n- `NAME`: Entry name/title\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**NAME**\\nSUMMARY\\nHIGHLIGHTS`.",
           "title": "Main Column",
           "type": "string"
         },
         "date_and_location_column": {
           "default": "*LOCATION*\n*DATE*",
-          "description": "Template for normal entry date/location column. Available placeholders:\n- `NAME`: Entry name/title\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
+          "description": "Template for normal entry date/location column. Available placeholders:\n- `NAME`: Entry name/title\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range (includes the time span when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`.",
           "title": "Date And Location Column",
           "type": "string"
         }

--- a/src/rendercv/renderer/templater/entry_templates_from_input.py
+++ b/src/rendercv/renderer/templater/entry_templates_from_input.py
@@ -144,6 +144,15 @@ def render_entry_templates[EntryType: Entry](
             key: template.replace(phrase_placeholder, phrase_template)
             for key, template in entry_templates.items()
         }
+    requested_placeholders = set(
+        uppercase_word_pattern.findall(" ".join(entry_templates.values()))
+    )
+
+    # When the user explicitly places TIME_SPAN in a template, suppress the
+    # automatic time-span suffix that DATE normally appends so the duration
+    # does not appear twice in the rendered output.
+    time_span_explicitly_used = "TIME_SPAN" in requested_placeholders
+    show_time_span_in_date = show_time_span and not time_span_explicitly_used
 
     # Handle special placeholders:
     if "HIGHLIGHTS" in entry_fields:
@@ -168,7 +177,7 @@ def render_entry_templates[EntryType: Entry](
             start_date=getattr(entry, "start_date", None),
             end_date=getattr(entry, "end_date", None),
             locale=locale,
-            show_time_span=show_time_span,
+            show_time_span=show_time_span_in_date,
             current_date=current_date,
             single_date_template=templates.single_date,
             date_range_template=templates.date_range,
@@ -194,6 +203,18 @@ def render_entry_templates[EntryType: Entry](
             locale=locale,
             single_date_template=templates.single_date,
         )
+
+    if time_span_explicitly_used:
+        start_date = getattr(entry, "start_date", None)
+        end_date = getattr(entry, "end_date", None)
+        if show_time_span and start_date is not None and end_date is not None:
+            entry_fields["TIME_SPAN"] = compute_time_span_string(
+                start_date,
+                end_date,
+                locale=locale,
+                current_date=current_date,
+                time_span_template=templates.time_span,
+            )
 
     if "URL" in entry_fields:
         entry_fields["URL"] = process_url(entry)  # ty: ignore[invalid-argument-type]

--- a/src/rendercv/schema/models/cv/cv.py
+++ b/src/rendercv/schema/models/cv/cv.py
@@ -163,14 +163,18 @@ class Cv(BaseModelWithoutExtraKeys):
             return data
 
         # Capture the input order before validation
-        key_order = list(data.keys()) if isinstance(data, dict) else []
+        key_order = (
+            [key for key in data if isinstance(key, str)]
+            if isinstance(data, dict)
+            else []
+        )
 
         # Let Pydantic do its validation
         instance = handler(data)
 
         # Set the private attribute on the instance:
         # If the values of those keys are None, remove the key from the key_order
-        instance._key_order = [key for key in key_order if data.get(key) is not None]  # ty: ignore[invalid-assignment]
+        instance._key_order = [key for key in key_order if data.get(key) is not None]
 
         return instance
 

--- a/src/rendercv/schema/models/design/classic_theme.py
+++ b/src/rendercv/schema/models/design/classic_theme.py
@@ -640,10 +640,12 @@ class EducationEntry(BaseModelWithoutExtraKeys):
             " `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n-"
             " `DEGREE`: Degree type (e.g., BS, PhD)\n- `DEGREE_WITH_AREA`: Locale-aware"
             " phrase combining degree and area (e.g., 'BS in Computer Science')\n-"
-            " `SUMMARY`: Summary text\n-"
-            " `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`:"
-            " Formatted date or date range\n\nYou can also add arbitrary keys to"
-            " entries and use them as UPPERCASE placeholders.\n\nThe default value is"
+            " `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n-"
+            " `LOCATION`: Location text\n- `DATE`: Formatted date or date range"
+            " (includes the time span when enabled)\n- `START_DATE`: Formatted start"
+            " date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated time"
+            " span string when enabled\n\nYou can also add arbitrary keys to entries"
+            " and use them as UPPERCASE placeholders.\n\nThe default value is"
             " `**INSTITUTION**, AREA\\nSUMMARY\\nHIGHLIGHTS`."
         ),
     )
@@ -654,10 +656,12 @@ class EducationEntry(BaseModelWithoutExtraKeys):
             " column. If `null`, no degree column is shown. Available placeholders:\n-"
             " `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n-"
             " `DEGREE`: Degree type (e.g., BS, PhD)\n- `SUMMARY`: Summary text\n-"
-            " `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`:"
-            " Formatted date or date range\n\nYou can also add arbitrary keys to"
-            " entries and use them as UPPERCASE placeholders.\n\nThe default value is"
-            " `**DEGREE**`."
+            " `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n-"
+            " `DATE`: Formatted date or date range (includes the time span when"
+            " enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`: Formatted"
+            " end date\n- `TIME_SPAN`: Calculated time span string when enabled\n\nYou"
+            " can also add arbitrary keys to entries and use them as UPPERCASE"
+            " placeholders.\n\nThe default value is `**DEGREE**`."
         ),
     )
     date_and_location_column: str = pydantic.Field(
@@ -667,9 +671,11 @@ class EducationEntry(BaseModelWithoutExtraKeys):
             " placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of"
             " study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `SUMMARY`:"
             " Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location"
-            " text\n- `DATE`: Formatted date or date range\n\nYou can also add"
-            " arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe"
-            " default value is `LOCATION\\nDATE`."
+            " text\n- `DATE`: Formatted date or date range (includes the time span"
+            " when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`:"
+            " Formatted end date\n- `TIME_SPAN`: Calculated time span string when"
+            " enabled\n\nYou can also add arbitrary keys to entries and use them as"
+            " UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`."
         ),
     )
 
@@ -681,8 +687,11 @@ class NormalEntry(BaseModelWithoutExtraKeys):
             "Template for normal entry main column. Available placeholders:\n- `NAME`:"
             " Entry name/title\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet"
             " points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or"
-            " date range\n\nYou can also add arbitrary keys to entries and use them as"
-            " UPPERCASE placeholders.\n\nThe default value is"
+            " date range (includes the time span when enabled)\n- `START_DATE`:"
+            " Formatted start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`:"
+            " Calculated time span string when enabled\n\nYou can also add arbitrary"
+            " keys to entries and use them as UPPERCASE placeholders.\n\nThe default"
+            " value is"
             " `**NAME**\\nSUMMARY\\nHIGHLIGHTS`."
         ),
     )
@@ -691,9 +700,12 @@ class NormalEntry(BaseModelWithoutExtraKeys):
         description=(
             "Template for normal entry date/location column. Available placeholders:\n-"
             " `NAME`: Entry name/title\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`:"
-            " Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date"
-            " or date range\n\nYou can also add arbitrary keys to entries and use them"
-            " as UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`."
+            " Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted"
+            " date or date range (includes the time span when enabled)\n-"
+            " `START_DATE`: Formatted start date\n- `END_DATE`: Formatted end date\n-"
+            " `TIME_SPAN`: Calculated time span string when enabled\n\nYou can also"
+            " add arbitrary keys to entries and use them as UPPERCASE placeholders."
+            "\n\nThe default value is `LOCATION\\nDATE`."
         ),
     )
 
@@ -705,9 +717,12 @@ class ExperienceEntry(BaseModelWithoutExtraKeys):
             "Template for experience entry main column. Available placeholders:\n-"
             " `COMPANY`: Company name\n- `POSITION`: Job title/position\n- `SUMMARY`:"
             " Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location"
-            " text\n- `DATE`: Formatted date or date range\n\nYou can also add"
-            " arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe"
-            " default value is `**COMPANY**, POSITION\\nSUMMARY\\nHIGHLIGHTS`."
+            " text\n- `DATE`: Formatted date or date range (includes the time span"
+            " when enabled)\n- `START_DATE`: Formatted start date\n- `END_DATE`:"
+            " Formatted end date\n- `TIME_SPAN`: Calculated time span string when"
+            " enabled\n\nYou can also add arbitrary keys to entries and use them as"
+            " UPPERCASE placeholders.\n\nThe default value is `**COMPANY**,"
+            " POSITION\\nSUMMARY\\nHIGHLIGHTS`."
         ),
     )
     date_and_location_column: str = pydantic.Field(
@@ -717,8 +732,11 @@ class ExperienceEntry(BaseModelWithoutExtraKeys):
             " placeholders:\n- `COMPANY`: Company name\n- `POSITION`: Job"
             " title/position\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points"
             " list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date"
-            " range\n\nYou can also add arbitrary keys to entries and use them as"
-            " UPPERCASE placeholders.\n\nThe default value is `LOCATION\\nDATE`."
+            " range (includes the time span when enabled)\n- `START_DATE`: Formatted"
+            " start date\n- `END_DATE`: Formatted end date\n- `TIME_SPAN`: Calculated"
+            " time span string when enabled\n\nYou can also add arbitrary keys to"
+            " entries and use them as UPPERCASE placeholders.\n\nThe default value is"
+            " `LOCATION\\nDATE`."
         ),
     )
 

--- a/tests/renderer/templater/test_entry_templates_from_input.py
+++ b/tests/renderer/templater/test_entry_templates_from_input.py
@@ -25,6 +25,9 @@ from rendercv.schema.models.design.classic_theme import (
     EducationEntry as EducationEntryOptions,
 )
 from rendercv.schema.models.design.classic_theme import (
+    ExperienceEntry as ExperienceEntryOptions,
+)
+from rendercv.schema.models.design.classic_theme import (
     NormalEntry as NormalEntryOptions,
 )
 from rendercv.schema.models.design.classic_theme import (
@@ -244,6 +247,77 @@ class TestRenderEntryTemplates:
         )
 
         assert entry.main_column == "Jan 2020 / Mar 2021 / / Jan 2020 – Mar 2021"  # ty: ignore[unresolved-attribute]
+
+    def test_populates_time_span_placeholder_in_custom_experience_template(self):
+        entry = ExperienceEntry(
+            company="Acme",
+            position="Engineer",
+            start_date="2020-01-01",
+            end_date="2021-03-01",
+        )
+
+        entry = render_entry_templates(
+            entry,
+            templates=Templates(
+                experience_entry=ExperienceEntryOptions(
+                    main_column="**COMPANY** | TIME_SPAN",
+                    date_and_location_column="START_DATE – END_DATE",
+                )
+            ),
+            locale=EnglishLocale(),
+            show_time_span=True,
+            current_date=Date(2024, 1, 1),
+        )
+
+        assert entry.main_column == "**Acme** | 1 year 3 months"  # ty: ignore[unresolved-attribute]
+        assert entry.date_and_location_column == "Jan 2020 – Mar 2021"  # ty: ignore[unresolved-attribute]
+
+    def test_suppresses_time_span_in_date_when_time_span_placeholder_is_used(self):
+        entry = NormalEntry(
+            name="Timeline",
+            start_date="2020-01-01",
+            end_date="2021-03-01",
+        )
+
+        entry = render_entry_templates(
+            entry,
+            templates=Templates(
+                normal_entry=NormalEntryOptions(
+                    main_column="START_DATE / END_DATE / TIME_SPAN / DATE",
+                )
+            ),
+            locale=EnglishLocale(),
+            show_time_span=True,
+            current_date=Date(2024, 1, 1),
+        )
+
+        # DATE should NOT include the appended time span when TIME_SPAN is
+        # explicitly placed in the template:
+        assert (
+            entry.main_column  # ty: ignore[unresolved-attribute]
+            == "Jan 2020 / Mar 2021 / 1 year 3 months / Jan 2020 – Mar 2021"
+        )
+
+    def test_removes_time_span_placeholder_when_disabled(self):
+        entry = NormalEntry(
+            name="Timeline",
+            start_date="2020-01-01",
+            end_date="2021-03-01",
+        )
+
+        entry = render_entry_templates(
+            entry,
+            templates=Templates(
+                normal_entry=NormalEntryOptions(
+                    main_column="NAME | TIME_SPAN",
+                )
+            ),
+            locale=EnglishLocale(),
+            show_time_span=False,
+            current_date=Date(2024, 1, 1),
+        )
+
+        assert entry.main_column == "Timeline"  # ty: ignore[unresolved-attribute]
 
     def test_handles_authors_doi_and_date_placeholders(self):
         entry = PublicationEntry(


### PR DESCRIPTION
## Summary

- Expose `TIME_SPAN` as a first-class template placeholder so users can place the computed duration string (e.g., "2 years 3 months") independently in custom entry templates
- Add `START_DATE` and `END_DATE` as standalone placeholders for ranged entries
- When `TIME_SPAN` is explicitly used in a template, suppress the automatic time-span suffix on `DATE` to prevent duplication
- Update schema descriptions and docs to document the new placeholders

Closes #547. Supersedes #696.

## Example

Users can now write custom templates like:

```yaml
experience_entry:
  main_column: |-
    **COMPANY**, LOCATION #h(1fr) TIME_SPAN · START_DATE – END_DATE
    POSITION
    SUMMARY
    HIGHLIGHTS
  date_and_location_column: ""
```

## Test plan

- [x] `TIME_SPAN` populates correctly in custom experience entry template
- [x] `DATE` suppresses appended time span when `TIME_SPAN` is explicitly used
- [x] `TIME_SPAN` is removed cleanly when time spans are disabled
- [x] `START_DATE` and `END_DATE` format correctly in custom templates
- [x] Existing `DATE` behavior preserved when `TIME_SPAN` is not used
- [x] Schema regenerated and matches model descriptions
- [x] `just check` passes (ruff, ty, pre-commit)
- [x] Full test suite passes (1385 tests)