### PR TITLE
Updated pattern matching algorithm, see #706

### DIFF
--- a/src/rendercv/renderer/templater/string_processor.py
+++ b/src/rendercv/renderer/templater/string_processor.py
@@ -61,11 +61,18 @@ def build_keyword_matcher_pattern(
         message = "Keywords cannot be empty"
         raise RenderCVInternalError(message)
 
-    escaped: list[str] = [re.escape(k) for k in keywords]
-    escaped.sort(key=len, reverse=True)
-    pattern = "(" + "|".join(escaped) + ")"
+    def add_word_boundaries(kw: str) -> str:
+        # Only add \b if the edge is a letter
+        start = "\\b" if kw and kw[0].isalnum() else ""
+        end = "\\b" if kw and kw[-1].isalnum() else ""
+        return f"{start}{re.escape(kw)}{end}"
+
     if word_boundary:
-        pattern = r"\b" + pattern + r"\b"
+        processed = [add_word_boundaries(k) for k in keywords]
+    else:
+        processed = [re.escape(k) for k in keywords]
+    processed.sort(key=len, reverse=True)
+    pattern = "(" + "|".join(processed) + ")"
     return re.compile(pattern)
 
 


### PR DESCRIPTION
Fix to issue [706](https://github.com/rendercv/rendercv/issues/706)

I tested it with the string`C++`, and the example provided by the user. In this case, both `Tech stack:` and `Tech stack: blabla` are getting bold. All tests in the repository seems to be passing, feel free to test it yourself.

<img width="1260" height="376" alt="image" src="https://github.com/user-attachments/assets/2734268a-7bbf-4e00-8b20-3ad8ef250857" />

